### PR TITLE
Use credentialsResolver consistently

### DIFF
--- a/src/handlers/common/GitHubCredentialsResolver.ts
+++ b/src/handlers/common/GitHubCredentialsResolver.ts
@@ -44,7 +44,7 @@ export class GitHubCredentialsResolver implements CredentialsResolver {
         } else if (this.hasToken(this.clientToken)) {
             return { token: this.clientToken };
         }
-        throw new Error("orgToken and clientToken has not been injected");
+        throw new Error("neither orgToken nor clientToken has been injected");
     }
 
     private hasToken(token: string) {

--- a/src/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
+++ b/src/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
@@ -26,11 +26,10 @@ import {
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import {
     EventHandlerMetadata,
-    ValueDeclaration,
 } from "@atomist/automation-client/metadata/automationMetadata";
 import {
     GoalExecutionListener,
-    GoalInvocation
+    GoalInvocation,
 } from "@atomist/sdm";
 import { executeGoal } from "@atomist/sdm/api-helper/goal/executeGoal";
 import { LoggingProgressLog } from "@atomist/sdm/api-helper/log/LoggingProgressLog";
@@ -60,10 +59,6 @@ export class FulfillGoalOnRequested implements HandleEvent<OnAnyRequestedSdmGoal
     public subscription: string;
     public name: string;
     public description: string;
-    // public secrets = [{name: "githubToken", uri: Secrets.OrgToken}];
-    public values = [ { path: "token", name: "githubToken", required: true } ] as any[] as ValueDeclaration[];
-
-    public githubToken: string;
 
     constructor(private readonly implementationMapper: SdmGoalImplementationMapper,
                 private readonly projectLoader: ProjectLoader,
@@ -103,7 +98,6 @@ export class FulfillGoalOnRequested implements HandleEvent<OnAnyRequestedSdmGoal
         const addressChannels = addressChannelsFor(sdmGoal.push.repo, ctx);
         const id = params.repoRefResolver.repoRefFromSdmGoal(sdmGoal);
 
-        (this.credentialsResolver as any).githubToken = params.githubToken;
         const credentials = this.credentialsResolver.eventHandlerCredentials(ctx, id);
 
         const goalInvocation: GoalInvocation = { sdmGoal, progressLog, context: ctx, addressChannels, id, credentials };

--- a/src/handlers/events/delivery/goals/GoalAutomationEventListener.ts
+++ b/src/handlers/events/delivery/goals/GoalAutomationEventListener.ts
@@ -29,6 +29,7 @@ import { RegistrationConfirmation } from "@atomist/automation-client/internal/tr
 import { guid } from "@atomist/automation-client/internal/util/string";
 import { AutomationEventListenerSupport } from "@atomist/automation-client/server/AutomationEventListener";
 import { QueryNoCacheOptions } from "@atomist/automation-client/spi/graph/GraphClient";
+import { GoalExecutionListener } from "@atomist/sdm";
 import { SdmGoalImplementationMapper } from "@atomist/sdm/api/goal/support/SdmGoalImplementationMapper";
 import { CredentialsResolver } from "@atomist/sdm/spi/credentials/CredentialsResolver";
 import { ProgressLogFactory } from "@atomist/sdm/spi/log/ProgressLog";
@@ -37,7 +38,6 @@ import { RepoRefResolver } from "@atomist/sdm/spi/repo-ref/RepoRefResolver";
 import * as cluster from "cluster";
 import { SdmGoalById } from "../../../../typings/types";
 import { FulfillGoalOnRequested } from "./FulfillGoalOnRequested";
-import { GoalExecutionListener } from "@atomist/sdm";
 
 export class GoalAutomationEventListener extends AutomationEventListenerSupport {
 

--- a/src/handlers/events/delivery/goals/RespondOnGoalCompletion.ts
+++ b/src/handlers/events/delivery/goals/RespondOnGoalCompletion.ts
@@ -22,16 +22,15 @@ import {
     HandlerResult,
     logger,
     Success,
-    Value,
 } from "@atomist/automation-client";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { SdmGoalEvent } from "@atomist/sdm";
-import { fetchGoalsForCommit } from "@atomist/sdm/api-helper/goal/fetchGoalsOnCommit";
-import { addressChannelsFor } from "@atomist/sdm/api/context/addressChannels";
 import {
     GoalCompletionListener,
     GoalCompletionListenerInvocation,
 } from "@atomist/sdm";
+import { fetchGoalsForCommit } from "@atomist/sdm/api-helper/goal/fetchGoalsOnCommit";
+import { addressChannelsFor } from "@atomist/sdm/api/context/addressChannels";
 import { CredentialsResolver } from "@atomist/sdm/spi/credentials/CredentialsResolver";
 import { RepoRefResolver } from "@atomist/sdm/spi/repo-ref/RepoRefResolver";
 import { isGoalRelevant } from "../../../../internal/delivery/goals/support/validateGoal";
@@ -42,9 +41,6 @@ import { OnAnyCompletedSdmGoal } from "../../../../typings/types";
  */
 @EventHandler("Run a listener on goal failure or success", subscription("OnAnyCompletedSdmGoal"))
 export class RespondOnGoalCompletion implements HandleEvent<OnAnyCompletedSdmGoal.Subscription> {
-
-    @Value("token")
-    public token: string;
 
     constructor(private readonly repoRefResolver: RepoRefResolver,
                 private readonly credentialsFactory: CredentialsResolver,
@@ -62,8 +58,6 @@ export class RespondOnGoalCompletion implements HandleEvent<OnAnyCompletedSdmGoa
 
         const id = this.repoRefResolver.repoRefFromPush(sdmGoal.push);
         const allGoals = await fetchGoalsForCommit(context, id, sdmGoal.repo.providerId, sdmGoal.goalSetId);
-
-        (this.credentialsFactory as any).githubToken = this.token;
 
         const gsi: GoalCompletionListenerInvocation = {
             id,

--- a/src/handlers/events/delivery/goals/VoteOnGoalApprovalRequest.ts
+++ b/src/handlers/events/delivery/goals/VoteOnGoalApprovalRequest.ts
@@ -22,7 +22,6 @@ import {
     HandlerResult,
     logger,
     Success,
-    Value,
 } from "@atomist/automation-client";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import {
@@ -51,9 +50,6 @@ import { OnAnyApprovedSdmGoal } from "../../../../typings/types";
     subscription("OnAnyApprovedSdmGoal"))
 export class VoteOnGoalApprovalRequest implements HandleEvent<OnAnyApprovedSdmGoal.Subscription> {
 
-    @Value("token")
-    public token: string;
-
     constructor(private readonly repoRefResolver: RepoRefResolver,
                 private readonly credentialsFactory: CredentialsResolver,
                 private readonly voters: GoalApprovalRequestVote[]) {
@@ -69,7 +65,6 @@ export class VoteOnGoalApprovalRequest implements HandleEvent<OnAnyApprovedSdmGo
         }
 
         const id = this.repoRefResolver.repoRefFromPush(sdmGoal.push);
-        (this.credentialsFactory as any).githubToken = this.token;
 
         const garvi: GoalApprovalRequestVoteInvocation = {
             id,
@@ -91,7 +86,7 @@ export class VoteOnGoalApprovalRequest implements HandleEvent<OnAnyApprovedSdmGo
             const goal: SdmGoalEvent = {
                 ...sdmGoal,
                 approval: undefined,
-            }
+            };
             await updateGoal(context, goal, {
                 state: SdmGoalState.waiting_for_approval,
                 description: `${sdmGoal.description} | approval request by @${sdmGoal.approval.userId} denied`,

--- a/src/internal/delivery/build/local/npm/executePublish.ts
+++ b/src/internal/delivery/build/local/npm/executePublish.ts
@@ -36,7 +36,6 @@ import * as p from "path";
 import { createStatus } from "../../../../../util/github/ghub";
 import { ProjectIdentifier } from "../projectIdentifier";
 import { NpmPreparations } from "./npmBuilder";
-import * as tmp from "tmp-promise";
 
 /**
  * Execute npm publish

--- a/src/internal/delivery/goals/support/github/gitHubStatusSetters.ts
+++ b/src/internal/delivery/goals/support/github/gitHubStatusSetters.ts
@@ -16,14 +16,14 @@
 
 import { logger } from "@atomist/automation-client";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import { goalKeyString } from "@atomist/sdm/api-helper/goal/sdmGoal";
-import { SdmGoal } from "@atomist/sdm/api/goal/SdmGoal";
 import {
     GoalCompletionListener,
     GoalCompletionListenerInvocation,
     GoalsSetListener,
     GoalsSetListenerInvocation,
 } from "@atomist/sdm";
+import { goalKeyString } from "@atomist/sdm/api-helper/goal/sdmGoal";
+import { SdmGoal } from "@atomist/sdm/api/goal/SdmGoal";
 import { CredentialsResolver } from "@atomist/sdm/spi/credentials/CredentialsResolver";
 import { StatusState } from "@atomist/sdm/typings/types";
 import { SdmGoalState } from "../../../../../typings/types";

--- a/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
+++ b/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
@@ -106,7 +106,8 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
                     this.configuration.sdm.repoRefResolver,
                     this.pushMapping,
                     this.goalsSetListeners,
-                    this.goalFulfillmentMapper, this.configuration.sdm.credentialsResolver)],
+                    this.goalFulfillmentMapper,
+                    this.configuration.sdm.credentialsResolver)],
                 commandHandlers: [() => resetGoalsCommand({
                     projectLoader: this.configuration.sdm.projectLoader,
                     repoRefResolver: this.configuration.sdm.repoRefResolver,
@@ -134,7 +135,8 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
                     () => new RequestDownstreamGoalsOnGoalSuccess(
                         this.configuration.name,
                         this.goalFulfillmentMapper,
-                        this.configuration.sdm.repoRefResolver),
+                        this.configuration.sdm.repoRefResolver,
+                        this.configuration.sdm.credentialsResolver),
                     () => new RespondOnGoalCompletion(
                         this.configuration.sdm.repoRefResolver,
                         this.configuration.sdm.credentialsResolver,

--- a/src/internal/machine/configureSdm.ts
+++ b/src/internal/machine/configureSdm.ts
@@ -21,8 +21,8 @@ import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/S
 import * as appRoot from "app-root-path";
 import * as _ from "lodash";
 import * as path from "path";
-import { defaultSoftwareDeliveryMachineOptions } from "../../machine/defaultSoftwareDeliveryMachineOptions";
 import { GoalAutomationEventListener } from "../../handlers/events/delivery/goals/GoalAutomationEventListener";
+import { defaultSoftwareDeliveryMachineOptions } from "../../machine/defaultSoftwareDeliveryMachineOptions";
 
 /**
  * Options that are used during configuration of an SDM but don't get passed on to the
@@ -80,7 +80,7 @@ export function configureSdm(
     };
 }
 
-function configureSdmToRunExactlyOneGoal(mergedConfig : SoftwareDeliveryMachineConfiguration, machine: SoftwareDeliveryMachine) {
+function configureSdmToRunExactlyOneGoal(mergedConfig: SoftwareDeliveryMachineConfiguration, machine: SoftwareDeliveryMachine) {
     if (process.env.ATOMIST_JOB_NAME) {
         mergedConfig.name = process.env.ATOMIST_REGISTRATION_NAME;
     } else {

--- a/src/pack/info/listGenerators.ts
+++ b/src/pack/info/listGenerators.ts
@@ -34,7 +34,7 @@ export function listGeneratorsHandler(sdm: SoftwareDeliveryMachine): CommandHand
         description: "List generators",
         intent: [ "list generators", "show generators" ],
     };
-};
+}
 
 function createListener(sdm: SoftwareDeliveryMachine): CommandListener<NoParameters> {
     return async cli => {


### PR DESCRIPTION
Remove usage of `@Value` to read `token` from configuration. This should be abstracted away in the pluggable `CredentialsResolver`. 

Extended the `GitHubCredentialsResolver` so that it can fall back on the client's token if no `orgToken` is provided as part of the event handler invocation. This currently happens for `SdmGoal` events. 

But now, you can plug in your own strategy for resolving credentials and it will get used across the board. 