### PR TITLE
Send timestamp to rolar as millis rather than a text string

### DIFF
--- a/src/log/RolarProgressLog.ts
+++ b/src/log/RolarProgressLog.ts
@@ -73,10 +73,12 @@ export class RolarProgressLog implements ProgressLog {
 
     public write(what: string) {
         const line = what || "";
+        const now: Date = this.timestamper.next().value;
         this.localLogs.push({
             level: this.logLevel,
             message: line,
-            timestamp: this.constructUtcTimestamp(),
+            timestamp: this.constructUtcTimestamp(now),
+            timestampMillis: this.constructMillisTimestamp(now),
         } as LogData);
         const bufferSize = this.localLogs.reduce((acc, logData) => acc + logData.message.length, 0);
         if (bufferSize > this.bufferSizeLimit) {
@@ -123,14 +125,17 @@ export class RolarProgressLog implements ProgressLog {
         return Promise.resolve();
     }
 
-    private constructUtcTimestamp(): string {
-        if (!this.timestamper) { return ""; }
-        const now: Date = this.timestamper.next().value;
+    private constructUtcTimestamp(d: Date): string {
+        const now: Date = d;
         const date = [now.getUTCMonth() + 1, now.getUTCDate(), now.getUTCFullYear()]
             .map(t => _.padStart(t.toString(), 2, "0"));
         const time = [now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds()]
             .map(t => _.padStart(t.toString(), 2, "0"));
         return `${date.join("/")} ${time.join(":")}.${_.padStart(now.getUTCMilliseconds().toString(), 3, "0")}`;
+    }
+
+    private constructMillisTimestamp(d: Date): number {
+        return  d.valueOf();
     }
 }
 
@@ -138,4 +143,5 @@ interface LogData {
     level: string;
     message: string;
     timestamp: string;
+    timestampMillis: number;
 }

--- a/test/log/RolarProgressLogTest.ts
+++ b/test/log/RolarProgressLogTest.ts
@@ -59,11 +59,13 @@ describe("RolarProgressLog", () => {
                 level: "info",
                 message: "I'm a lumberjack and I'm OK",
                 timestamp: "01/01/1970 00:00:00.000",
+                timestampMillis: 0,
             },
             {
                 level: "info",
                 message: "I sleep all night and I work all day",
                 timestamp: "01/01/1970 00:00:00.001",
+                timestampMillis: 1,
             },
         ]);
     });
@@ -80,11 +82,13 @@ describe("RolarProgressLog", () => {
                     level: "info",
                     message: "He's a lumberjack and he's OK",
                     timestamp: "01/01/1970 00:00:00.000",
+                    timestampMillis: 0,
                 },
                 {
                     level: "info",
                     message: "He sleeps all night and he works all day",
                     timestamp: "01/01/1970 00:00:00.001",
+                    timestampMillis: 1,
                 },
             ];
             const actualRequest = JSON.parse(config.data).content;
@@ -116,11 +120,13 @@ describe("RolarProgressLog", () => {
                 level: "info",
                 message: "I cut down trees, I eat my lunch",
                 timestamp: "01/01/1970 00:00:00.000",
+                timestampMillis: 0,
             },
             {
                 level: "info",
                 message: "I go to the lavatory",
                 timestamp: "01/01/1970 00:00:00.001",
+                timestampMillis: 1,
             },
         ]);
     });
@@ -137,6 +143,7 @@ describe("RolarProgressLog", () => {
                         level: "info",
                         message: "On Wednesdays I go shopping and have buttered scones for tea",
                         timestamp: "01/01/1970 00:00:00.000",
+                        timestampMillis: 0,
                     },
                 ];
                 const actualRequest = JSON.parse(config.data).content;
@@ -199,31 +206,13 @@ describe("RolarProgressLog", () => {
                 level: "debug",
                 message: "I'm a lumberjack and I'm OK",
                 timestamp: "01/01/1970 00:00:00.000",
+                timestampMillis: 0,
             },
             {
                 level: "debug",
                 message: "I sleep all night and I work all day",
                 timestamp: "01/01/1970 00:00:00.001",
-            },
-        ]);
-    });
-
-    it("should log without timestamp", async () => {
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, 0, "", null);
-
-        log.write("I'm a lumberjack and I'm OK");
-        log.write("I sleep all night and I work all day");
-
-        assert.deepEqual((log as any).localLogs, [
-            {
-                level: "",
-                message: "I'm a lumberjack and I'm OK",
-                timestamp: "",
-            },
-            {
-                level: "",
-                message: "I sleep all night and I work all day",
-                timestamp: "",
+                timestampMillis: 1,
             },
         ]);
     });


### PR DESCRIPTION
This change sends both for backwards compatibility, but the currently deployed rolar prefers millis.
This will keep use from having to construct and parse a specific date format, and puts the formatting logic on the server side rather than the long writing side.
Removed a test where the timestamper was null, because that is a silly test. There is a default value for that, and it is fine for it to be a required value.