### PR TITLE
Move local configuration into configuration object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atomist/automation-client": {
-      "version": "1.0.0-M.1",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.0.0-M.1.tgz",
-      "integrity": "sha512-wT8GOszVpuz/Hytq5RteKPvaOjPS9Pu5ULBaxBQ5QyW8KIWy31p6MpwWaUdjY7bGTxCm885g64aN9r40O6U1rA==",
+      "version": "1.0.0-master.20180829070856",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.0.0-master.20180829070856.tgz",
+      "integrity": "sha512-eyZb2i3+wm/CGIoDG4x+EJGjyZCakDRflnBccuFkCn2PMJ7AY4tvlMf/SyqSKUwy44BBIL5mtsHnm8wmev5kpA==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^0.8.1",
@@ -1048,7 +1048,7 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@atomist/sdm": "*"
   },
   "devDependencies": {
-    "@atomist/automation-client": "1.0.0-M.1",
+    "@atomist/automation-client": "1.0.0-master.20180829070856",
     "@atomist/sdm": "1.0.0-M.1",
     "@types/lodash": "^4.14.116",
     "@types/mocha": "^5.2.5",

--- a/src/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
+++ b/src/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
@@ -25,7 +25,6 @@ import {
     Success,
 } from "@atomist/automation-client";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
-import { possibleAxiosObjectReplacer } from "@atomist/automation-client/internal/transport/AbstractRequestProcessor";
 import {
     GoalExecutionListener,
     GoalInvocation,
@@ -44,8 +43,8 @@ import {
 import { ProjectLoader } from "@atomist/sdm/spi/project/ProjectLoader";
 import { RepoRefResolver } from "@atomist/sdm/spi/repo-ref/RepoRefResolver";
 import { OnAnyRequestedSdmGoal } from "@atomist/sdm/typings/types";
-import * as stringify from "json-stringify-safe";
 import { isGoalRelevant } from "../../../../internal/delivery/goals/support/validateGoal";
+import { serializeResult } from "../../../../util/misc/result";
 import { formatDuration } from "../../../../util/misc/time";
 
 /**
@@ -136,7 +135,7 @@ async function reportStart(sdmGoal: SdmGoalEvent, progressLog: ProgressLog) {
 
 async function reportEndAndClose(result: any, start: number, progressLog: ProgressLog) {
     progressLog.write(`/--`);
-    progressLog.write(`Result: ${stringify(result, possibleAxiosObjectReplacer, 0)}`);
+    progressLog.write(`Result: ${serializeResult(result)}`);
     progressLog.write(`Duration: ${formatDuration(Date.now() - start)}`);
     progressLog.write("\\--");
     await progressLog.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,8 @@ export { EphemeralLocalArtifactStore } from "./internal/artifact/local/Ephemeral
 export { selfDescribingHandlers } from "./pack/info/support/commandSearch";
 export { WellKnownGoals } from "./pack/well-known-goals/addWellKnownGoals";
 export {
-    LocalModeConfiguration,
+    LocalSoftwareDeliveryMachineOptions,
+    LocalSoftwareDeliveryMachineConfiguration,
     isInLocalMode,
     IsInLocalMode,
-} from "./internal/machine/LocalModeConfiguration";
+} from "./internal/machine/LocalSoftwareDeliveryMachineOptions";

--- a/src/internal/delivery/build/local/SpawnBuilder.ts
+++ b/src/internal/delivery/build/local/SpawnBuilder.ts
@@ -15,7 +15,6 @@
  */
 
 import { logger } from "@atomist/automation-client";
-import { possibleAxiosObjectReplacer } from "@atomist/automation-client/internal/transport/AbstractRequestProcessor";
 import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
@@ -38,6 +37,7 @@ import { ProgressLog } from "@atomist/sdm/spi/log/ProgressLog";
 import { SpawnOptions } from "child_process";
 import * as _ from "lodash";
 import { sprintf } from "sprintf-js";
+import { serializeResult } from "../../../../util/misc/result";
 import {
     LocalBuilder,
     LocalBuildInProgress,
@@ -170,12 +170,8 @@ export class SpawnBuilder extends LocalBuilder implements LogInterpretation {
                         if (br.error) {
                             throw new Error("Build failure: " + br.error);
                         }
-                        const r = {
-                            ...br,
-                        };
-                        delete r.childProcess;
                         log.write("/--");
-                        log.write(`Result: ${JSON.stringify(r, possibleAxiosObjectReplacer, 0)}`);
+                        log.write(`Result: ${serializeResult(br)}`);
                         log.write("\\--");
                         return executeOne(buildCommand);
                     });

--- a/src/internal/delivery/goals/support/githubStatusSummarySupport.ts
+++ b/src/internal/delivery/goals/support/githubStatusSummarySupport.ts
@@ -16,7 +16,7 @@
 
 import { SoftwareDeliveryMachine } from "@atomist/sdm/api/machine/SoftwareDeliveryMachine";
 import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
-import { isInLocalMode } from "../../../..";
+import { isInLocalMode } from "../../../machine/LocalSoftwareDeliveryMachineOptions";
 import {
     createPendingGitHubStatusOnGoalSet,
     SetGitHubStatusOnGoalCompletion,

--- a/src/internal/machine/LocalSoftwareDeliveryMachineOptions.ts
+++ b/src/internal/machine/LocalSoftwareDeliveryMachineOptions.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { PushTest } from "@atomist/sdm";
+import { AnyOptions } from "@atomist/automation-client/configuration";
+import {
+    PushTest,
+    SoftwareDeliveryMachineConfiguration,
+} from "@atomist/sdm";
 
 /**
  * Configuration determining how to run in local mode
  */
-export interface LocalModeConfiguration {
+export interface LocalSoftwareDeliveryMachineOptions {
 
     /**
      * Base of expanded directory tree the local client will work with:
@@ -39,6 +43,11 @@ export interface LocalModeConfiguration {
      * Whether to merge autofixes automatically
      */
     mergeAutofixes?: boolean;
+
+    /**
+     * Name of host to use for creating local url
+     */
+    hostname?: string;
 }
 
 /**
@@ -56,3 +65,10 @@ export const IsInLocalMode: PushTest = {
     name: "IsInLocalMode",
     mapping: async () => isInLocalMode(),
 };
+
+/**
+ * Configuration that takes SoftwareDeliveryMachineOptions inside the sdm key.
+ */
+export interface LocalSoftwareDeliveryMachineConfiguration extends SoftwareDeliveryMachineConfiguration {
+    local: LocalSoftwareDeliveryMachineOptions & AnyOptions;
+}

--- a/src/internal/util/startupMessage.ts
+++ b/src/internal/util/startupMessage.ts
@@ -18,6 +18,7 @@ import { Configuration } from "@atomist/automation-client";
 import { BannerSection } from "@atomist/automation-client/configuration";
 import { SoftwareDeliveryMachine } from "@atomist/sdm";
 import chalk from "chalk";
+import { isInLocalMode } from "../machine/LocalSoftwareDeliveryMachineOptions";
 
 /**
  * Print some SDM details to the startup banner of the client
@@ -27,7 +28,7 @@ export function sdmStartupMessage(sdm: SoftwareDeliveryMachine):
     (configuration: Configuration) => string | BannerSection {
     return () => ({
         title: "SDM",
-        body: `${sdm.name}  ${process.env.ATOMIST_MODE === "local" ? `${chalk.gray("Local")} true` : "" }`,
+        body: `${sdm.name}${isInLocalMode() ? `  ${chalk.grey("started in")} ${chalk.green("local mode")}` : ""}`,
     });
 }
 

--- a/src/machine/defaultSoftwareDeliveryMachineConfiguration.ts
+++ b/src/machine/defaultSoftwareDeliveryMachineConfiguration.ts
@@ -18,15 +18,14 @@ import { Configuration } from "@atomist/automation-client";
 import { RemoteGitProjectPersister } from "@atomist/automation-client/operations/generate/remoteGitProjectPersister";
 import { allReposInTeam } from "@atomist/sdm/api-helper/command/transform/allReposInTeam";
 import { CachingProjectLoader } from "@atomist/sdm/api-helper/project/CachingProjectLoader";
-import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import * as _ from "lodash";
 import { DefaultRepoRefResolver } from "../handlers/common/DefaultRepoRefResolver";
 import { GitHubCredentialsResolver } from "../handlers/common/GitHubCredentialsResolver";
 import { EphemeralLocalArtifactStore } from "../internal/artifact/local/EphemeralLocalArtifactStore";
-import { ConfigureOptions } from "../internal/machine/configureSdm";
+import { LocalSoftwareDeliveryMachineConfiguration } from "../internal/machine/LocalSoftwareDeliveryMachineOptions";
 import { rolarAndDashboardLogFactory } from "../log/rolarAndDashboardLogFactory";
 
-export function defaultSoftwareDeliveryMachineOptions(configuration: Configuration): SoftwareDeliveryMachineConfiguration {
+export function defaultSoftwareDeliveryMachineConfiguration(configuration: Configuration): LocalSoftwareDeliveryMachineConfiguration {
     const repoRefResolver = new DefaultRepoRefResolver();
     return {
         sdm: {
@@ -40,12 +39,6 @@ export function defaultSoftwareDeliveryMachineOptions(configuration: Configurati
             repoFinder: allReposInTeam(repoRefResolver),
             projectPersister: RemoteGitProjectPersister,
         },
-    };
-}
-
-export function defaultConfigureOptions(): ConfigureOptions {
-    return {
-        requiredConfigurationValues: [],
         local: {
             preferLocalSeeds: true,
         },

--- a/src/util/misc/result.ts
+++ b/src/util/misc/result.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { possibleAxiosObjectReplacer } from "@atomist/automation-client/internal/transport/AbstractRequestProcessor";
+import * as stringify from "json-stringify-safe";
+import * as _ from "lodash";
+
+export function serializeResult(result: any): string {
+    const safeResult = _.omit(result, "childProcess");
+    return stringify(safeResult, possibleAxiosObjectReplacer, 0);
+}

--- a/test/util/misc/resultTest.ts
+++ b/test/util/misc/resultTest.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChildProcessResult } from "@atomist/sdm/api-helper/misc/spawned";
+import * as assert from "power-assert";
+import { serializeResult } from "../../../src/util/misc/result";
+
+describe("result", () => {
+
+    it("should strip childProcess from string", () => {
+        const result: ChildProcessResult = {
+            childProcess: {
+                foo: "bar",
+            },
+            message: "test",
+            error: "error",
+            code: 100,
+        } as any;
+        const safeResult = JSON.parse(serializeResult(result));
+        delete result.childProcess;
+        assert.deepEqual(safeResult, result);
+    });
+});


### PR DESCRIPTION
Local configuration options can now be configured via the normal ways:

```typescript
export const configuration: Configuration = {
  local: {
    repositoryOwnerParentDirectory: os.homedir(),
    hostname: "localhost",
  }
}
```

Also cleans up the banner message to more prominently print local mode info.