### PR TITLE
Make reset goals optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 -   **BREAKING** Move local configuration into configuration object. [#34](https://github.com/atomist/sdm-core/issues/34)
+-   **BREAKING** Moved "set goal state" and "reset goals" into an extension pack. Add it in your SDM if you want these: `sdm.addExtensionPacks(GoalState)`
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -320,7 +320,7 @@
     },
     "@atomist/tree-path": {
       "version": "0.1.9",
-      "resolved": "http://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-0.1.9.tgz",
       "integrity": "sha512-lDTCBAd8lJeWswipBHFDvVNj5AMcYgHEX7jd9yZJbuRii8cLXJVxOPTTyczmEtG367YzMSm61AKBzY7ucSE3Ow==",
       "dev": true,
       "requires": {
@@ -1122,7 +1122,7 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {
@@ -2850,7 +2850,7 @@
     },
     "graphql": {
       "version": "0.13.2",
-      "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
       "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
       "dev": true,
       "requires": {

--- a/src/handlers/commands/disposeCommand.ts
+++ b/src/handlers/commands/disposeCommand.ts
@@ -32,11 +32,7 @@ import {
     chooseAndSetGoals,
     ChooseAndSetGoalsRules,
 } from "@atomist/sdm/api-helper/goal/chooseAndSetGoals";
-import {
-    fetchDefaultBranchTip,
-    fetchPushForCommit,
-    tipOfBranch,
-} from "../events/delivery/goals/resetGoals";
+import { fetchDefaultBranchTip, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
 
 @Parameters()
 export class DisposeParameters {
@@ -53,7 +49,7 @@ export class DisposeParameters {
     @MappedParameter(MappedParameters.GitHubRepositoryProvider)
     public providerId: string;
 
-    @Parameter({required: true})
+    @Parameter({ required: true })
     public areYouSure: string;
 }
 
@@ -75,12 +71,12 @@ function disposeOfProject(rules: ChooseAndSetGoalsRules) {
         const branch = repoData.defaultBranch;
         const sha = tipOfBranch(repoData, branch);
 
-        const id = GitHubRepoRef.from({owner: commandParams.owner, repo: commandParams.repo, sha, branch});
+        const id = GitHubRepoRef.from({ owner: commandParams.owner, repo: commandParams.repo, sha, branch });
         const push = await fetchPushForCommit(ctx, id, commandParams.providerId);
 
         const determinedGoals = await chooseAndSetGoals(rules, {
             context: ctx,
-            credentials: {token: commandParams.githubToken},
+            credentials: { token: commandParams.githubToken },
             push,
         });
         if (!determinedGoals) {

--- a/src/handlers/commands/disposeCommand.ts
+++ b/src/handlers/commands/disposeCommand.ts
@@ -32,7 +32,7 @@ import {
     chooseAndSetGoals,
     ChooseAndSetGoalsRules,
 } from "@atomist/sdm/api-helper/goal/chooseAndSetGoals";
-import { fetchDefaultBranchTip, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
+import { fetchBranchTips, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
 
 @Parameters()
 export class DisposeParameters {
@@ -67,7 +67,7 @@ function disposeOfProject(rules: ChooseAndSetGoalsRules) {
             return ctx.messageClient.respond("You didn't say 'yes' to 'are you sure?' so I won't do anything.")
                 .then(success);
         }
-        const repoData = await fetchDefaultBranchTip(ctx, commandParams);
+        const repoData = await fetchBranchTips(ctx, commandParams);
         const branch = repoData.defaultBranch;
         const sha = tipOfBranch(repoData, branch);
 

--- a/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
+++ b/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
@@ -49,18 +49,18 @@ export class SetGoalsOnPush implements HandleEvent<OnPushToAnyBranch.Subscriptio
      * @param credentialsFactory credentials factory
      */
     constructor(private readonly projectLoader: ProjectLoader,
-                private readonly repoRefResolver: RepoRefResolver,
-                private readonly goalSetter: GoalSetter,
-                public readonly goalsListeners: GoalsSetListener[],
-                private readonly implementationMapping: GoalImplementationMapper,
-                private readonly credentialsFactory: CredentialsResolver) {
+        private readonly repoRefResolver: RepoRefResolver,
+        private readonly goalSetter: GoalSetter,
+        public readonly goalsListeners: GoalsSetListener[],
+        private readonly implementationMapping: GoalImplementationMapper,
+        private readonly credentialsFactory: CredentialsResolver) {
     }
 
     public async handle(event: EventFired<OnPushToAnyBranch.Subscription>,
-                        context: HandlerContext,
-                        params: this): Promise<HandlerResult> {
+        context: HandlerContext,
+        params: this): Promise<HandlerResult> {
         const push: OnPushToAnyBranch.Push = event.data.Push[0];
-        const id: RemoteRepoRef = params.repoRefResolver.toRemoteRepoRef(push.repo, {});
+        const id: RemoteRepoRef = this.repoRefResolver.toRemoteRepoRef(push.repo, {});
         const credentials = this.credentialsFactory.eventHandlerCredentials(context, id);
 
         await chooseAndSetGoals({
@@ -70,10 +70,10 @@ export class SetGoalsOnPush implements HandleEvent<OnPushToAnyBranch.Subscriptio
             goalSetter: params.goalSetter,
             implementationMapping: params.implementationMapping,
         }, {
-            context,
-            credentials,
-            push,
-        });
+                context,
+                credentials,
+                push,
+            });
         return Success;
     }
 }

--- a/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
+++ b/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
@@ -49,16 +49,16 @@ export class SetGoalsOnPush implements HandleEvent<OnPushToAnyBranch.Subscriptio
      * @param credentialsFactory credentials factory
      */
     constructor(private readonly projectLoader: ProjectLoader,
-        private readonly repoRefResolver: RepoRefResolver,
-        private readonly goalSetter: GoalSetter,
-        public readonly goalsListeners: GoalsSetListener[],
-        private readonly implementationMapping: GoalImplementationMapper,
-        private readonly credentialsFactory: CredentialsResolver) {
+                private readonly repoRefResolver: RepoRefResolver,
+                private readonly goalSetter: GoalSetter,
+                public readonly goalsListeners: GoalsSetListener[],
+                private readonly implementationMapping: GoalImplementationMapper,
+                private readonly credentialsFactory: CredentialsResolver) {
     }
 
     public async handle(event: EventFired<OnPushToAnyBranch.Subscription>,
-        context: HandlerContext,
-        params: this): Promise<HandlerResult> {
+                        context: HandlerContext,
+                        params: this): Promise<HandlerResult> {
         const push: OnPushToAnyBranch.Push = event.data.Push[0];
         const id: RemoteRepoRef = this.repoRefResolver.toRemoteRepoRef(push.repo, {});
         const credentials = this.credentialsFactory.eventHandlerCredentials(context, id);

--- a/src/handlers/events/delivery/goals/resetGoals.ts
+++ b/src/handlers/events/delivery/goals/resetGoals.ts
@@ -50,12 +50,10 @@ import {
     PushForCommit,
     RepoBranchTips,
 } from "../../../../typings/types";
+import { CommandHandlerRegistration, CommandListenerInvocation } from "@atomist/sdm";
 
 @Parameters()
 export class ResetGoalsParameters {
-
-    @Secret(Secrets.UserToken)
-    public githubToken: string;
 
     @MappedParameter(MappedParameters.GitHubOwner)
     public owner: string;
@@ -66,10 +64,10 @@ export class ResetGoalsParameters {
     @MappedParameter(MappedParameters.GitHubRepositoryProvider)
     public providerId: string;
 
-    @Parameter({required: false})
+    @Parameter({ required: false })
     public sha: string;
 
-    @Parameter({required: false})
+    @Parameter({ required: false })
     public branch: string;
 
     @Value("name")
@@ -87,18 +85,15 @@ export function resetGoalsCommand(rules: {
     goalSetter: GoalSetter,
     implementationMapping: GoalImplementationMapper,
     name: string,
-}): HandleCommand {
-    return commandHandlerFrom(resetGoalsOnCommit(rules),
-        ResetGoalsParameters,
-        "ResetGoalsOnCommit",
-        "Set goals",
-        [
-            `plan goals ${rules.name.replace("@", "")}`,
-            "plan goals",
-            `reset goals ${rules.name.replace("@", "")}`,
-            "reset goals",
-        ]);
+}): CommandHandlerRegistration {
+    return {
+        name: "ResetGoalsOnCommit",
+        paramsMaker: ResetGoalsParameters,
+        listener: resetGoalsOnCommit(rules),
+        intent: ["reset goals"],
+    }
 }
+
 
 function resetGoalsOnCommit(rules: {
     projectLoader: ProjectLoader,
@@ -107,43 +102,38 @@ function resetGoalsOnCommit(rules: {
     goalSetter: GoalSetter,
     implementationMapping: GoalImplementationMapper,
 }) {
-    const {projectLoader, goalsListeners, goalSetter, implementationMapping, repoRefResolver} = rules;
-    return async (ctx: HandlerContext, commandParams: ResetGoalsParameters) => {
-        // figure out which commit
-        const repoData = await fetchDefaultBranchTip(ctx, commandParams);
+    return async (cli: CommandListenerInvocation<ResetGoalsParameters>) => {
+        const commandParams = cli.parameters;
+        const repoData = await fetchDefaultBranchTip(cli.context, cli.parameters);
         const branch = commandParams.branch || repoData.defaultBranch;
         const sha = commandParams.sha || tipOfBranch(repoData, branch);
-        const id = GitHubRepoRef.from({owner: commandParams.owner, repo: commandParams.repo, sha, branch});
+        const id = rules.repoRefResolver.toRemoteRepoRef({
+            owner: commandParams.owner, name: commandParams.repo,
+            org: { owner: commandParams.owner, provider: { providerId: commandParams.providerId } }
+        }, { sha, branch });
 
-        const push = await fetchPushForCommit(ctx, id, commandParams.providerId);
-        const credentials = {token: commandParams.githubToken};
+        const push = await fetchPushForCommit(cli.context, id, commandParams.providerId);
 
-        const goals = await chooseAndSetGoals({
-            projectLoader,
-            repoRefResolver,
-            goalsListeners,
-            goalSetter,
-            implementationMapping,
-        }, {
-            context: ctx,
-            credentials,
+        const goals = await chooseAndSetGoals(rules, {
+            context: cli.context,
+            credentials: cli.credentials,
             push,
         });
 
         if (goals) {
-            await ctx.messageClient.respond(success(
+            await cli.addressChannels(success(
                 "Plan Goals",
                 `Successfully planned goals on ${codeLine(sha.slice(0, 7))} of ${
-                    bold(`${commandParams.owner}/${commandParams.repo}/${branch}`)} to ${italic(goals.name)}`,
+                bold(`${commandParams.owner}/${commandParams.repo}/${branch}`)} to ${italic(goals.name)}`,
                 {
                     footer: `${commandParams.name}:${commandParams.version}`,
                 }));
         } else {
-            await ctx.messageClient.respond(warning(
+            await cli.addressChannels(warning(
                 "Plan Goals",
                 `No goals found for ${codeLine(sha.slice(0, 7))} of ${
-                    bold(`${commandParams.owner}/${commandParams.repo}/${branch}`)}`,
-                ctx,
+                bold(`${commandParams.owner}/${commandParams.repo}/${branch}`)}`,
+                cli.context,
                 {
                     footer: `${commandParams.name}:${commandParams.version}`,
                 }));
@@ -172,7 +162,7 @@ export async function fetchPushForCommit(context: HandlerContext, id: RemoteRepo
 
 export async function fetchDefaultBranchTip(ctx: HandlerContext, repositoryId: { repo: string, owner: string, providerId: string }) {
     const result = await ctx.graphClient.query<RepoBranchTips.Query, RepoBranchTips.Variables>(
-        {name: "RepoBranchTips", variables: {name: repositoryId.repo, owner: repositoryId.owner}});
+        { name: "RepoBranchTips", variables: { name: repositoryId.repo, owner: repositoryId.owner } });
     if (!result || !result.Repo || result.Repo.length === 0) {
         throw new Error(`Repository not found: ${repositoryId.owner}/${repositoryId.repo}`);
     }

--- a/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
+++ b/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
@@ -99,14 +99,7 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
                     this.goalsSetListeners,
                     this.goalFulfillmentMapper,
                     this.configuration.sdm.credentialsResolver)],
-                commandHandlers: [() => resetGoalsCommand({
-                    projectLoader: this.configuration.sdm.projectLoader,
-                    repoRefResolver: this.configuration.sdm.repoRefResolver,
-                    goalsListeners: this.goalsSetListeners,
-                    goalSetter: this.pushMapping,
-                    implementationMapping: this.goalFulfillmentMapper,
-                    name: this.configuration.name,
-                })],
+                commandHandlers: [],
                 ingesters: [],
             };
         } else {
@@ -274,12 +267,20 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
      * @param {GoalSetter} goalSetters tell me what to do on a push. Hint: start with "whenPushSatisfies(...)"
      */
     constructor(name: string,
-                configuration: Configuration & SoftwareDeliveryMachineConfiguration,
-                goalSetters: Array<GoalSetter | GoalSetter[]>) {
+        configuration: Configuration & SoftwareDeliveryMachineConfiguration,
+        goalSetters: Array<GoalSetter | GoalSetter[]>) {
         super(name, configuration, goalSetters);
         // This hits the Atomist service
         this.addFingerprintListener(SendFingerprintToAtomist);
         this.addExtensionPacks(WellKnownGoals);
+        this.addCommand(resetGoalsCommand({
+            projectLoader: this.configuration.sdm.projectLoader,
+            repoRefResolver: this.configuration.sdm.repoRefResolver,
+            goalsListeners: this.goalsSetListeners,
+            goalSetter: this.pushMapping,
+            implementationMapping: this.goalFulfillmentMapper,
+            name: this.configuration.name,
+        }));
     }
 
 }

--- a/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
+++ b/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
@@ -38,7 +38,6 @@ import { ReactToSemanticDiffsOnPushImpact } from "../../handlers/events/delivery
 import { OnDeployStatus } from "../../handlers/events/delivery/deploy/OnDeployStatus";
 import { FulfillGoalOnRequested } from "../../handlers/events/delivery/goals/FulfillGoalOnRequested";
 import { RequestDownstreamGoalsOnGoalSuccess } from "../../handlers/events/delivery/goals/RequestDownstreamGoalsOnGoalSuccess";
-import { resetGoalsCommand } from "../../handlers/events/delivery/goals/resetGoals";
 import { RespondOnGoalCompletion } from "../../handlers/events/delivery/goals/RespondOnGoalCompletion";
 import { SetGoalsOnPush } from "../../handlers/events/delivery/goals/SetGoalsOnPush";
 import { SkipDownstreamGoalsOnGoalFailure } from "../../handlers/events/delivery/goals/SkipDownstreamGoalsOnGoalFailure";
@@ -267,25 +266,12 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
      * @param {GoalSetter} goalSetters tell me what to do on a push. Hint: start with "whenPushSatisfies(...)"
      */
     constructor(name: string,
-        configuration: Configuration & SoftwareDeliveryMachineConfiguration,
-        goalSetters: Array<GoalSetter | GoalSetter[]>) {
+                configuration: Configuration & SoftwareDeliveryMachineConfiguration,
+                goalSetters: Array<GoalSetter | GoalSetter[]>) {
         super(name, configuration, goalSetters);
         // This hits the Atomist service
         this.addFingerprintListener(SendFingerprintToAtomist);
         this.addExtensionPacks(WellKnownGoals);
-    }
-
-    public includeResetGoalCommand(): this {
-        // this would be an extension pack, except it needs the unpublic field pushmapping
-        this.addCommand(resetGoalsCommand({
-            projectLoader: this.configuration.sdm.projectLoader,
-            repoRefResolver: this.configuration.sdm.repoRefResolver,
-            goalsListeners: this.goalsSetListeners,
-            goalSetter: this.pushMapping,
-            implementationMapping: this.goalFulfillmentMapper,
-            name: this.configuration.name,
-        }));
-        return this;
     }
 
 }

--- a/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
+++ b/src/internal/machine/HandlerBasedSoftwareDeliveryMachine.ts
@@ -273,6 +273,10 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
         // This hits the Atomist service
         this.addFingerprintListener(SendFingerprintToAtomist);
         this.addExtensionPacks(WellKnownGoals);
+    }
+
+    public includeResetGoalCommand(): this {
+        // this would be an extension pack, except it needs the unpublic field pushmapping
         this.addCommand(resetGoalsCommand({
             projectLoader: this.configuration.sdm.projectLoader,
             repoRefResolver: this.configuration.sdm.repoRefResolver,
@@ -281,6 +285,7 @@ export class HandlerBasedSoftwareDeliveryMachine extends AbstractSoftwareDeliver
             implementationMapping: this.goalFulfillmentMapper,
             name: this.configuration.name,
         }));
+        return this;
     }
 
 }

--- a/src/machine/machineFactory.ts
+++ b/src/machine/machineFactory.ts
@@ -63,14 +63,10 @@ import { ExposeInfo } from "../pack/info/exposeInfo";
  */
 export function createSoftwareDeliveryMachine(config: MachineConfiguration<SoftwareDeliveryMachineConfiguration>,
     // tslint:disable-next-line:max-line-length
-                                              ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
+    ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
     const machine = new HandlerBasedSoftwareDeliveryMachine(config.name, config.configuration,
         goalSetters);
     machine.addExtensionPacks(ExposeInfo);
-
-    if (!isInLocalMode()) {
-        machine.addExtensionPacks(GoalState);
-    }
 
     return machine;
 }

--- a/src/machine/machineFactory.ts
+++ b/src/machine/machineFactory.ts
@@ -1,3 +1,4 @@
+import { SetGoalState } from './../pack/info/setGoalState';
 /*
  * Copyright © 2018 Atomist, Inc.
  *
@@ -20,6 +21,7 @@ import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/S
 import { GoalSetter } from "@atomist/sdm/api/mapping/GoalSetter";
 import { HandlerBasedSoftwareDeliveryMachine } from "../internal/machine/HandlerBasedSoftwareDeliveryMachine";
 import { ExposeInfo } from "../pack/info/exposeInfo";
+import { isInLocalMode } from "../internal/machine/LocalSoftwareDeliveryMachineOptions";
 
 /**
  * Create a **Software Delivery MachineConfiguration** with default predefined goals.
@@ -60,10 +62,16 @@ import { ExposeInfo } from "../pack/info/exposeInfo";
  * ```
  */
 export function createSoftwareDeliveryMachine(config: MachineConfiguration<SoftwareDeliveryMachineConfiguration>,
-                                              // tslint:disable-next-line:max-line-length
-                                              ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
+    // tslint:disable-next-line:max-line-length
+    ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
     const machine = new HandlerBasedSoftwareDeliveryMachine(config.name, config.configuration,
         goalSetters);
-    return machine
-        .addExtensionPacks(ExposeInfo);
+    machine.addExtensionPacks(ExposeInfo);
+
+    if (isInLocalMode()) {
+        machine.includeResetGoalCommand();
+        machine.addExtensionPacks(SetGoalState);
+    }
+
+    return machine;
 }

--- a/src/machine/machineFactory.ts
+++ b/src/machine/machineFactory.ts
@@ -1,4 +1,3 @@
-import { SetGoalState } from './../pack/info/setGoalState';
 /*
  * Copyright © 2018 Atomist, Inc.
  *
@@ -20,8 +19,9 @@ import { SoftwareDeliveryMachine } from "@atomist/sdm/api/machine/SoftwareDelive
 import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
 import { GoalSetter } from "@atomist/sdm/api/mapping/GoalSetter";
 import { HandlerBasedSoftwareDeliveryMachine } from "../internal/machine/HandlerBasedSoftwareDeliveryMachine";
-import { ExposeInfo } from "../pack/info/exposeInfo";
 import { isInLocalMode } from "../internal/machine/LocalSoftwareDeliveryMachineOptions";
+import { GoalState } from "../pack/goalState/goalState";
+import { ExposeInfo } from "../pack/info/exposeInfo";
 
 /**
  * Create a **Software Delivery MachineConfiguration** with default predefined goals.
@@ -63,14 +63,13 @@ import { isInLocalMode } from "../internal/machine/LocalSoftwareDeliveryMachineO
  */
 export function createSoftwareDeliveryMachine(config: MachineConfiguration<SoftwareDeliveryMachineConfiguration>,
     // tslint:disable-next-line:max-line-length
-    ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
+                                              ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
     const machine = new HandlerBasedSoftwareDeliveryMachine(config.name, config.configuration,
         goalSetters);
     machine.addExtensionPacks(ExposeInfo);
 
-    if (isInLocalMode()) {
-        machine.includeResetGoalCommand();
-        machine.addExtensionPacks(SetGoalState);
+    if (!isInLocalMode()) {
+        machine.addExtensionPacks(GoalState);
     }
 
     return machine;

--- a/src/machine/machineFactory.ts
+++ b/src/machine/machineFactory.ts
@@ -63,7 +63,7 @@ import { ExposeInfo } from "../pack/info/exposeInfo";
  */
 export function createSoftwareDeliveryMachine(config: MachineConfiguration<SoftwareDeliveryMachineConfiguration>,
     // tslint:disable-next-line:max-line-length
-    ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
+                                              ...goalSetters: Array<GoalSetter | GoalSetter[]>): SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
     const machine = new HandlerBasedSoftwareDeliveryMachine(config.name, config.configuration,
         goalSetters);
     machine.addExtensionPacks(ExposeInfo);

--- a/src/pack/goalState/goalState.ts
+++ b/src/pack/goalState/goalState.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { ExtensionPack } from "@atomist/sdm";
+import { ExtensionPack, logger } from "@atomist/sdm";
 import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
 import { resetGoalsCommand } from "./resetGoals";
 import { setGoalStateCommand } from "./setGoalState";
+import { isInLocalMode } from "../../internal/machine/LocalSoftwareDeliveryMachineOptions";
 
 /**
  * allow goal setting
@@ -25,7 +26,13 @@ import { setGoalStateCommand } from "./setGoalState";
 export const GoalState: ExtensionPack = {
     ...metadata("set goal state"),
     configure: sdm => {
-        sdm.addCommand(setGoalStateCommand(sdm));
-        sdm.addCommand(resetGoalsCommand(sdm));
+        if (isInLocalMode()) {
+            logger.warn("Setting goal state is not available in local mode.")
+            logger.warn("Resetting goals does not work in local mode. Use `atomist trigger post-commit` instead.")
+        } else {
+            sdm.addCommand(setGoalStateCommand(sdm));
+            sdm.addCommand(resetGoalsCommand(sdm));
+        }
     },
 };
+x

--- a/src/pack/goalState/goalState.ts
+++ b/src/pack/goalState/goalState.ts
@@ -1,0 +1,22 @@
+import { ExtensionPack } from "@atomist/sdm";
+import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
+import { resetGoalsCommand } from "./resetGoals";
+import { setGoalStateCommand } from "./setGoalState";
+
+/**
+ * allow goal setting
+ */
+export const GoalState: ExtensionPack = {
+    ...metadata("set goal state"),
+    configure: sdm => {
+        sdm.addCommand(setGoalStateCommand(sdm));
+        sdm.addCommand(resetGoalsCommand({
+            projectLoader: sdm.configuration.sdm.projectLoader,
+            repoRefResolver: sdm.configuration.sdm.repoRefResolver,
+            goalsListeners: sdm.goalsSetListeners,
+            goalSetter: sdm.pushMapping,
+            implementationMapping: sdm.goalFulfillmentMapper,
+            name: sdm.configuration.name,
+        }));
+    },
+};

--- a/src/pack/goalState/goalState.ts
+++ b/src/pack/goalState/goalState.ts
@@ -10,13 +10,6 @@ export const GoalState: ExtensionPack = {
     ...metadata("set goal state"),
     configure: sdm => {
         sdm.addCommand(setGoalStateCommand(sdm));
-        sdm.addCommand(resetGoalsCommand({
-            projectLoader: sdm.configuration.sdm.projectLoader,
-            repoRefResolver: sdm.configuration.sdm.repoRefResolver,
-            goalsListeners: sdm.goalsSetListeners,
-            goalSetter: sdm.pushMapping,
-            implementationMapping: sdm.goalFulfillmentMapper,
-            name: sdm.configuration.name,
-        }));
+        sdm.addCommand(resetGoalsCommand(sdm));
     },
 };

--- a/src/pack/goalState/goalState.ts
+++ b/src/pack/goalState/goalState.ts
@@ -35,4 +35,3 @@ export const GoalState: ExtensionPack = {
         }
     },
 };
-x

--- a/src/pack/goalState/goalState.ts
+++ b/src/pack/goalState/goalState.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ExtensionPack } from "@atomist/sdm";
 import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
 import { resetGoalsCommand } from "./resetGoals";

--- a/src/pack/goalState/goalState.ts
+++ b/src/pack/goalState/goalState.ts
@@ -16,9 +16,9 @@
 
 import { ExtensionPack, logger } from "@atomist/sdm";
 import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
+import { isInLocalMode } from "../../internal/machine/LocalSoftwareDeliveryMachineOptions";
 import { resetGoalsCommand } from "./resetGoals";
 import { setGoalStateCommand } from "./setGoalState";
-import { isInLocalMode } from "../../internal/machine/LocalSoftwareDeliveryMachineOptions";
 
 /**
  * allow goal setting
@@ -27,8 +27,8 @@ export const GoalState: ExtensionPack = {
     ...metadata("set goal state"),
     configure: sdm => {
         if (isInLocalMode()) {
-            logger.warn("Setting goal state is not available in local mode.")
-            logger.warn("Resetting goals does not work in local mode. Use `atomist trigger post-commit` instead.")
+            logger.warn("Setting goal state is not available in local mode.");
+            logger.warn("Resetting goals does not work in local mode. Use `atomist trigger post-commit` instead.");
         } else {
             sdm.addCommand(setGoalStateCommand(sdm));
             sdm.addCommand(resetGoalsCommand(sdm));

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -87,7 +87,7 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
             goalsListeners: sdm.goalsSetListeners,
             goalSetter: sdm.pushMapping,
             implementationMapping: sdm.goalFulfillmentMapper,
-        }
+        };
 
         const commandParams = cli.parameters;
         const repoData = await fetchDefaultBranchTip(cli.context, cli.parameters);

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -83,13 +83,7 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
         };
 
         const commandParams = { ...cli.parameters, ...cli.parameters.targets.repoRef };
-        const repoData = await fetchDefaultBranchTip(cli.context, commandParams);
-        const branch = commandParams.branch || repoData.defaultBranch;
-        const sha = commandParams.sha || tipOfBranch(repoData, branch);
-        const id = rules.repoRefResolver.toRemoteRepoRef({
-            owner: commandParams.owner, name: commandParams.repo,
-            org: { owner: commandParams.owner, provider: { providerId: commandParams.providerId } },
-        }, { sha, branch });
+        const id = cli.parameters.targets.repoRef;
 
         const push = await fetchPushForCommit(cli.context, id, commandParams.providerId);
 
@@ -102,16 +96,16 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
         if (goals) {
             await cli.addressChannels(success(
                 "Plan Goals",
-                `Successfully planned goals on ${codeLine(sha.slice(0, 7))} of ${
-                bold(`${commandParams.owner}/${commandParams.repo}/${branch}`)} to ${italic(goals.name)}`,
+                `Successfully planned goals on ${codeLine(push.after.sha.slice(0, 7))} of ${
+                bold(`${commandParams.owner}/${commandParams.repo}/${push.branch}`)} to ${italic(goals.name)}`,
                 {
                     footer: `${commandParams.name}:${commandParams.version}`,
                 }));
         } else {
             await cli.addressChannels(warning(
                 "Plan Goals",
-                `No goals found for ${codeLine(sha.slice(0, 7))} of ${
-                bold(`${commandParams.owner}/${commandParams.repo}/${branch}`)}`,
+                `No goals found for ${codeLine(push.after.sha.slice(0, 7))} of ${
+                bold(`${commandParams.owner}/${commandParams.repo}/${push.branch}`)}`,
                 cli.context,
                 {
                     footer: `${commandParams.name}:${commandParams.version}`,

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -84,7 +84,7 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
         if (!isValidSHA1(id.sha)) {
             logger.info("Fetching tip of branch %s", id.branch);
             const allBranchTips = await fetchBranchTips(cli.context, {
-                repo: id.repo, owner: id.owner, providerId: cli.parameters.providerId
+                repo: id.repo, owner: id.owner, providerId: cli.parameters.providerId,
             });
             id.sha = tipOfBranch(allBranchTips, id.branch);
             logger.info("Learned that the tip of %s is %s", id.branch, id.sha);

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -15,12 +15,12 @@
  */
 
 import {
+    logger,
     MappedParameter,
     MappedParameters,
     Parameter,
     Success,
     Value,
-    logger,
 } from "@atomist/automation-client";
 import { Parameters } from "@atomist/automation-client/decorators";
 import { CommandHandlerRegistration, CommandListenerInvocation, GitHubRepoTargets, SoftwareDeliveryMachine } from "@atomist/sdm";

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -22,9 +22,10 @@ import {
     Value,
 } from "@atomist/automation-client";
 import { Parameters } from "@atomist/automation-client/decorators";
-import { CommandHandlerRegistration, CommandListenerInvocation, SoftwareDeliveryMachine, GitHubRepoTargets } from "@atomist/sdm";
+import { CommandHandlerRegistration, CommandListenerInvocation, GitHubRepoTargets, SoftwareDeliveryMachine } from "@atomist/sdm";
 import { chooseAndSetGoals } from "@atomist/sdm/api-helper/goal/chooseAndSetGoals";
 import { toRepoTargetingParametersMaker } from "@atomist/sdm/api-helper/machine/handlerRegistrations";
+import { RepoTargetingParameters } from "@atomist/sdm/api-helper/machine/RepoTargetingParameters";
 import {
     success,
     warning,
@@ -44,7 +45,6 @@ import {
     RepoBranchTips,
 } from "../../typings/types";
 import { fetchDefaultBranchTip, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
-import { RepoTargetingParameters } from "@atomist/sdm/api-helper/machine/RepoTargetingParameters";
 
 @Parameters()
 export class ResetGoalsParameters extends GitHubRepoTargets {
@@ -82,7 +82,7 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
             implementationMapping: sdm.goalFulfillmentMapper,
         };
 
-        const commandParams = { ...cli.parameters, ...cli.parameters.targets.repoRef, };
+        const commandParams = { ...cli.parameters, ...cli.parameters.targets.repoRef };
         const repoData = await fetchDefaultBranchTip(cli.context, commandParams);
         const branch = commandParams.branch || repoData.defaultBranch;
         const sha = commandParams.sha || tipOfBranch(repoData, branch);

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -31,11 +31,6 @@ import {
     success,
     warning,
 } from "@atomist/sdm/api-helper/misc/slack/messages";
-import { GoalImplementationMapper } from "@atomist/sdm/api/goal/support/GoalImplementationMapper";
-import { GoalsSetListener } from "@atomist/sdm/api/listener/GoalsSetListener";
-import { GoalSetter } from "@atomist/sdm/api/mapping/GoalSetter";
-import { ProjectLoader } from "@atomist/sdm/spi/project/ProjectLoader";
-import { RepoRefResolver } from "@atomist/sdm/spi/repo-ref/RepoRefResolver";
 import {
     bold,
     codeLine,
@@ -45,7 +40,7 @@ import {
     PushForCommit,
     RepoBranchTips,
 } from "../../typings/types";
-import { fetchDefaultBranchTip, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
+import { fetchBranchTips, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
 
 @Parameters()
 export class ResetGoalsParameters extends GitHubRepoTargets {
@@ -88,7 +83,10 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
 
         if (!isValidSHA1(id.sha)) {
             logger.info("Fetching tip of branch %s", id.branch);
-            id.sha = await tipOfBranch(id, id.branch);
+            const allBranchTips = await fetchBranchTips(cli.context, {
+                repo: id.repo, owner: id.owner, providerId: cli.parameters.providerId
+            });
+            id.sha = tipOfBranch(allBranchTips, id.branch);
             logger.info("Learned that the tip of %s is %s", id.branch, id.sha);
         }
 

--- a/src/pack/goalState/setGoalState.ts
+++ b/src/pack/goalState/setGoalState.ts
@@ -43,7 +43,7 @@ import {
     SlackMessage,
 } from "@atomist/slack-messages";
 import * as _ from "lodash";
-import { fetchDefaultBranchTip, tipOfBranch } from "../../util/graph/queryCommits";
+import { fetchBranchTips, tipOfBranch } from "../../util/graph/queryCommits";
 
 @Parameters()
 class SetGoalStateParameters {
@@ -94,7 +94,7 @@ export function setGoalStateCommand(sdm: SoftwareDeliveryMachine): CommandHandle
                 chi.parameters.msgId = guid();
             }
             const footer = `${chi.parameters.name}:${chi.parameters.version}`;
-            const repoData = await fetchDefaultBranchTip(chi.context, chi.parameters);
+            const repoData = await fetchBranchTips(chi.context, chi.parameters);
             const branch = chi.parameters.branch || repoData.defaultBranch;
             const sha = chi.parameters.sha || tipOfBranch(repoData, branch);
             const id = GitHubRepoRef.from({ owner: chi.parameters.owner, repo: chi.parameters.repo, sha, branch });

--- a/src/pack/goalState/setGoalState.ts
+++ b/src/pack/goalState/setGoalState.ts
@@ -29,9 +29,9 @@ import {
 } from "@atomist/automation-client/spi/message/MessageClient";
 import {
     CommandHandlerRegistration,
+    ExtensionPack,
     SdmGoalState,
     SoftwareDeliveryMachine,
-    ExtensionPack,
 } from "@atomist/sdm";
 import { fetchGoalsForCommit } from "@atomist/sdm/api-helper/goal/fetchGoalsOnCommit";
 import { updateGoal } from "@atomist/sdm/api-helper/goal/storeGoals";
@@ -43,21 +43,7 @@ import {
     SlackMessage,
 } from "@atomist/slack-messages";
 import * as _ from "lodash";
-import {
-    fetchDefaultBranchTip,
-    tipOfBranch,
-} from "../../handlers/events/delivery/goals/resetGoals";
-import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
-
-/**
- * allow goal setting
- */
-export const SetGoalState: ExtensionPack = {
-    ...metadata("set goal state"),
-    configure: sdm => {
-        sdm.addCommand(setGoalStateCommand(sdm))
-    },
-};
+import { fetchDefaultBranchTip, tipOfBranch } from "../../util/graph/queryCommits";
 
 @Parameters()
 class SetGoalStateParameters {

--- a/src/pack/info/exposeInfo.ts
+++ b/src/pack/info/exposeInfo.ts
@@ -24,6 +24,6 @@ import { selfDescribeCommand } from "./SelfDescribe";
 export const ExposeInfo: ExtensionPack = {
     ...metadata("info"),
     configure: sdm => {
-        sdm.addCommand(selfDescribeCommand(sdm))
+        sdm.addCommand(selfDescribeCommand(sdm));
     },
 };

--- a/src/pack/info/exposeInfo.ts
+++ b/src/pack/info/exposeInfo.ts
@@ -17,7 +17,6 @@
 import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
 import { ExtensionPack } from "@atomist/sdm/api/machine/ExtensionPack";
 import { selfDescribeCommand } from "./SelfDescribe";
-import { setGoalStateCommand } from "./setGoalState";
 
 /**
  * Expose information about this machine
@@ -26,6 +25,5 @@ export const ExposeInfo: ExtensionPack = {
     ...metadata("info"),
     configure: sdm => {
         sdm.addCommand(selfDescribeCommand(sdm))
-            .addCommand(setGoalStateCommand(sdm));
     },
 };

--- a/src/pack/info/setGoalState.ts
+++ b/src/pack/info/setGoalState.ts
@@ -31,6 +31,7 @@ import {
     CommandHandlerRegistration,
     SdmGoalState,
     SoftwareDeliveryMachine,
+    ExtensionPack,
 } from "@atomist/sdm";
 import { fetchGoalsForCommit } from "@atomist/sdm/api-helper/goal/fetchGoalsOnCommit";
 import { updateGoal } from "@atomist/sdm/api-helper/goal/storeGoals";
@@ -46,6 +47,17 @@ import {
     fetchDefaultBranchTip,
     tipOfBranch,
 } from "../../handlers/events/delivery/goals/resetGoals";
+import { metadata } from "@atomist/sdm/api-helper/misc/extensionPack";
+
+/**
+ * allow goal setting
+ */
+export const SetGoalState: ExtensionPack = {
+    ...metadata("set goal state"),
+    configure: sdm => {
+        sdm.addCommand(setGoalStateCommand(sdm))
+    },
+};
 
 @Parameters()
 class SetGoalStateParameters {
@@ -129,9 +141,9 @@ export function setGoalStateCommand(sdm: SoftwareDeliveryMachine): CommandHandle
                             codeLine(sha.slice(0, 7))} of ${bold(`${id.owner}/${id.repo}/${branch}`)}:`,
                         actions: [
                             menuForCommand({
-                                    text: "Goals",
-                                    options: optionsGroups,
-                                },
+                                text: "Goals",
+                                options: optionsGroups,
+                            },
                                 "SetGoalState",
                                 "goal",
                                 { ...chi.parameters }),
@@ -182,7 +194,7 @@ export function setGoalStateCommand(sdm: SoftwareDeliveryMachine): CommandHandle
                     success(
                         "Set Goal State",
                         `Successfully set state of ${italic(goal.name)} on ${codeLine(sha.slice(0, 7))} of ${
-                            bold(`${id.owner}/${id.repo}`)} to ${italic(chi.parameters.state)}`,
+                        bold(`${id.owner}/${id.repo}`)} to ${italic(chi.parameters.state)}`,
                         { footer }),
                     { id: chi.parameters.msgId });
             }

--- a/src/util/graph/queryCommits.ts
+++ b/src/util/graph/queryCommits.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { HandlerContext } from "@atomist/automation-client";
 import { PushFields, RemoteRepoRef } from "@atomist/sdm";
 import * as stringify from "json-stringify-safe";

--- a/src/util/graph/queryCommits.ts
+++ b/src/util/graph/queryCommits.ts
@@ -37,7 +37,7 @@ export async function fetchPushForCommit(context: HandlerContext, id: RemoteRepo
 }
 
 export async function fetchBranchTips(ctx: HandlerContext,
-    repositoryId: { repo: string, owner: string, providerId: string }): Promise<RepoBranchTips.Repo> {
+                                      repositoryId: { repo: string, owner: string, providerId: string }): Promise<RepoBranchTips.Repo> {
     const result = await ctx.graphClient.query<RepoBranchTips.Query, RepoBranchTips.Variables>(
         { name: "RepoBranchTips", variables: { name: repositoryId.repo, owner: repositoryId.owner } });
     if (!result || !result.Repo || result.Repo.length === 0) {

--- a/src/util/graph/queryCommits.ts
+++ b/src/util/graph/queryCommits.ts
@@ -1,0 +1,42 @@
+import { HandlerContext } from "@atomist/automation-client";
+import { PushFields, RemoteRepoRef } from "@atomist/sdm";
+import * as stringify from "json-stringify-safe";
+import { PushForCommit, RepoBranchTips } from "../../typings/types";
+
+export async function fetchPushForCommit(context: HandlerContext, id: RemoteRepoRef, providerId: string): Promise<PushFields.Fragment> {
+    const commitResult = await context.graphClient.query<PushForCommit.Query, PushForCommit.Variables>({
+        name: "PushForCommit", variables: {
+            owner: id.owner, repo: id.repo, providerId, branch: id.branch, sha: id.sha,
+        },
+    });
+
+    if (!commitResult || !commitResult.Commit || commitResult.Commit.length === 0) {
+        throw new Error("Could not find commit for " + stringify(id));
+    }
+    const commit = commitResult.Commit[0];
+    if (!commit.pushes || commit.pushes.length === 0) {
+        throw new Error("Could not find push for " + stringify(id));
+    }
+    return commit.pushes[0];
+}
+
+export async function fetchDefaultBranchTip(ctx: HandlerContext, repositoryId: { repo: string, owner: string, providerId: string }) {
+    const result = await ctx.graphClient.query<RepoBranchTips.Query, RepoBranchTips.Variables>(
+        { name: "RepoBranchTips", variables: { name: repositoryId.repo, owner: repositoryId.owner } });
+    if (!result || !result.Repo || result.Repo.length === 0) {
+        throw new Error(`Repository not found: ${repositoryId.owner}/${repositoryId.repo}`);
+    }
+    const repo = result.Repo.find(r => r.org.provider.providerId === repositoryId.providerId);
+    if (!repo) {
+        throw new Error(`Repository not found: ${repositoryId.owner}/${repositoryId.repo} provider ${repositoryId.providerId}`);
+    }
+    return repo;
+}
+
+export function tipOfBranch(repo: RepoBranchTips.Repo, branchName: string) {
+    const branchData = repo.branches.find(b => b.name === branchName);
+    if (!branchData) {
+        throw new Error("Branch not found: " + branchName);
+    }
+    return branchData.commit.sha;
+}

--- a/src/util/graph/queryCommits.ts
+++ b/src/util/graph/queryCommits.ts
@@ -36,7 +36,8 @@ export async function fetchPushForCommit(context: HandlerContext, id: RemoteRepo
     return commit.pushes[0];
 }
 
-export async function fetchDefaultBranchTip(ctx: HandlerContext, repositoryId: { repo: string, owner: string, providerId: string }) {
+export async function fetchBranchTips(ctx: HandlerContext,
+    repositoryId: { repo: string, owner: string, providerId: string }): Promise<RepoBranchTips.Repo> {
     const result = await ctx.graphClient.query<RepoBranchTips.Query, RepoBranchTips.Variables>(
         { name: "RepoBranchTips", variables: { name: repositoryId.repo, owner: repositoryId.owner } });
     if (!result || !result.Repo || result.Repo.length === 0) {


### PR DESCRIPTION
This moves "reset goals" into the extension pack with "set goal state", and does not add that extension pack in the constructor. Add it yourself if you want it.

It also makes resetGoals work with the CommandHandlerRegistration infrastructure, and the TargetRepoParams like a transform. (the latter is necessary for the former).
