### PR TITLE
Make it possible to target a SHA on a branch

### DIFF
--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -54,6 +54,9 @@ export class ResetGoalsParameters extends GitHubRepoTargets {
     @Value("version")
     public version: string;
 
+    @Parameter()
+    public thing: string;
+
 }
 
 export function resetGoalsCommand(sdm: SoftwareDeliveryMachine): CommandHandlerRegistration {

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -43,7 +43,7 @@ import {
 import { fetchBranchTips, fetchPushForCommit, tipOfBranch } from "../../util/graph/queryCommits";
 
 @Parameters()
-export class ResetGoalsParameters extends GitHubRepoTargets {
+export class ResetGoalsParameters {
 
     @MappedParameter(MappedParameters.GitHubRepositoryProvider)
     public providerId: string;

--- a/src/pack/goalState/resetGoals.ts
+++ b/src/pack/goalState/resetGoals.ts
@@ -54,8 +54,8 @@ export class ResetGoalsParameters {
     @Value("version")
     public version: string;
 
-    @Parameter()
-    public thing: string;
+    @Parameter({ required: false })
+    public branch: string;
 
 }
 
@@ -91,6 +91,9 @@ function resetGoalsOnCommit(sdm: SoftwareDeliveryMachine) {
             });
             id.sha = tipOfBranch(allBranchTips, id.branch);
             logger.info("Learned that the tip of %s is %s", id.branch, id.sha);
+        } else {
+            // they gave us a real SHA. Hopefully they gave us the branch too.
+            id.branch = cli.parameters.branch || "master";
         }
 
         const push = await fetchPushForCommit(cli.context, id, commandParams.providerId);


### PR DESCRIPTION
This isn't what we want, but maybe it can get us until Monday when I can tackle this for real?

`@Atomist reset goals branch=test targets.sha=021de0d9da03d67426415537a23757d2cb99819a` will let you reset goals on an arbitrary sha on a branch.

Or for the tip of the branch:
`@Atomist reset goals targets.sha=test` (I know, not ideal)

still defaults to tip of master.