### PR TITLE
Add commit-images link to GraphQL

### DIFF
--- a/lib/graphql/fragment/PushFields.graphql
+++ b/lib/graphql/fragment/PushFields.graphql
@@ -25,6 +25,10 @@ fragment PushFields on Push {
       image
       imageName
     }
+    images {
+      image
+      imageName
+    }
     tags {
       name
       description


### PR DESCRIPTION
Add the newer images link to commits.  The image link was not removed,
so this is backward compatible.