### PR TITLE
Support for goal contributions as data

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -175,3 +175,9 @@ export {
     GoalCache,
     GoalCacheOptions,
 } from "./lib/goal/cache/goalCaching";
+export {
+    configure,
+    Configurer,
+    GoalData,
+    GoalStructure,
+} from "./lib/machine/configure";

--- a/lib/machine/configure.ts
+++ b/lib/machine/configure.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Configuration } from "@atomist/automation-client";
+import {
+    allSatisfied,
+    AnyPush,
+    Goal,
+    GoalContribution,
+    goals,
+    Goals,
+    PushListenerInvocation,
+    PushTest,
+    SdmContext,
+    SoftwareDeliveryMachine,
+    whenPushSatisfies,
+} from "@atomist/sdm";
+import * as _ from "lodash";
+import {
+    ConfigureOptions,
+    configureSdm,
+} from "../internal/machine/configureSdm";
+import { toArray } from "../util/misc/array";
+import { createSoftwareDeliveryMachine } from "./machineFactory";
+
+/**
+ * Data structure to configure goal contributions
+ */
+export interface GoalStructure {
+
+    /**
+     * Optional push tests to determine when to schedule provided goals
+     *
+     * If an array of push tests is provided, they will get wrapped with allSatisfied/and.
+     */
+    test?: PushTest | PushTest[];
+
+    /** Optional pre conditions for goals; can be actual goal instances or names of goal contributions */
+    dependsOn?: string | Goal | Array<string | Goal>;
+
+    /**
+     * Goal instances to schedule
+     *
+     * The following cases are supported:
+     *
+     * goals: [
+     *  autofix,
+     *  build
+     * ]
+     *
+     * This means autofix will run after build
+     *
+     * goals: [
+     *  [autofix, build]
+     * ]
+     *
+     * This will schedule autofix and build concurrently
+     *
+     * goals: [
+     *  [autofix, build],
+     *  dockerBuild
+     * ]
+     *
+     * This will schedule autofix and build concurrently and dockerBuild once autofix and build are completed
+     */
+    goals: Goal | Goals | Array<Goal | Goals | Array<Goal | Goals>>;
+}
+
+/**
+ * Type to collect named GoalStructure instances
+ *
+ * The record key will be used to name the goal contribution.
+ */
+export type GoalData = Record<string, GoalStructure>;
+
+/**
+ * Configure a SoftwareDeliveryMachine instance by adding command, events etc and optionally returning
+ * GoalData, an array of GoalContributions or void when no goals should be added to this SDM.
+ */
+export type Configurer<F extends SdmContext = PushListenerInvocation> = (sdm: SoftwareDeliveryMachine) =>
+    Promise<void | GoalData | Array<GoalContribution<F>>>;
+
+/**
+ * Function to create an SDM configuration constant to be exported from an index.ts/js.
+ */
+export function configure<T extends SdmContext = PushListenerInvocation>(configurer: Configurer<T>,
+                                                                         options: { name?: string } & ConfigureOptions = {}): Configuration {
+    return {
+        postProcessors: [
+            configureSdm(async cfg => {
+                const sdm = createSoftwareDeliveryMachine(
+                    {
+                        name: options.name || cfg.name,
+                        configuration: cfg,
+                    });
+
+                const configured = await configurer(sdm);
+
+                if (Array.isArray(configured)) {
+                    sdm.withPushRules(configured[0], ...configured.slice(1));
+                } else if (!!configured) {
+                    const goalContributions = convertGoalData(configured);
+                    sdm.withPushRules(goalContributions[0], ...(goalContributions.slice(1) || []));
+                }
+
+                return sdm;
+            }, options),
+        ],
+    };
+}
+
+/**
+ * Convert the provided GoalData instance into an array of GoalContributions
+ */
+export function convertGoalData(goalData: GoalData): Array<GoalContribution<any>> {
+    const goalContributions: Array<GoalContribution<any>> = [];
+
+    _.forEach(goalData, (v, k) => {
+        (v as any).__goals = [];
+
+        const gs = goals(k.replace(/_/g, " "));
+        let lg: Array<Goal | Goals>;
+
+        if (!!v.dependsOn) {
+            lg = [];
+            toArray(v.dependsOn).forEach(d => {
+                if (typeof d === "string") {
+                    if (!!goalData[d] && !!(goalData[d] as any).__goals) {
+                        lg.push(...(goalData[d] as any).__goals);
+                    } else {
+                        throw new Error(
+                            `Provided dependsOn goals with name '${d}' do not exist or is after current goals named '${k}'`);
+                    }
+                } else {
+                    lg.push(...toArray(d));
+                }
+            });
+        }
+
+        toArray(v.goals || []).forEach(g => {
+            (v as any).__goals.push(...(Array.isArray(g) ? (g) : [g]));
+            if (!!lg) {
+                gs.plan(...convertGoals(g)).after(...convertGoals(lg));
+            } else {
+                gs.plan(...convertGoals(g));
+            }
+            lg = toArray(g);
+        });
+
+        goalContributions.push(whenPushSatisfies(convertPushTest(v.test)).setGoals(gs));
+    });
+
+    return goalContributions;
+}
+
+function convertPushTest(test: PushTest | PushTest[]): PushTest {
+    if (Array.isArray(test)) {
+        return allSatisfied(...test);
+    } else {
+        return test || AnyPush;
+    }
+}
+
+function convertGoals(gs: Goal | Goals | Array<Goal | Goals>): Array<Goal | Goals> {
+    if (Array.isArray(gs)) {
+        return gs;
+    } else {
+        return [gs];
+    }
+}

--- a/test/machine/configure.test.ts
+++ b/test/machine/configure.test.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    goal,
+    hasFile,
+} from "@atomist/sdm";
+import * as assert from "power-assert";
+import {
+    convertGoalData,
+    GoalData,
+} from "../../lib/machine/configure";
+
+describe("configure", () => {
+
+    const g1 = goal({ uniqueName: "goal1" });
+    const g2 = goal({ uniqueName: "goal2" });
+    const g3 = goal({ uniqueName: "goal3" });
+
+    describe("convertGoalData", () => {
+
+        it("should convert single goal", () => {
+            const gd: GoalData = {
+                test_underscore: {
+                    test: [hasFile("bla.json"), hasFile("foo.bar")],
+                    goals: g1,
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 1);
+            const gc: any = gcs[0];
+            assert.strictEqual(gc.goalsName, "test underscore");
+            const g = gc.staticValue.goals;
+            assert.strictEqual(g.length, 1);
+            assert.strictEqual(g[0], g1);
+        });
+
+        it("should convert two goals", () => {
+            const gd: GoalData = {
+                test: {
+                    goals: [g1, g2],
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 1);
+            const gc: any = gcs[0];
+            assert.strictEqual(gc.goalsName, "test");
+            const g = gc.staticValue.goals;
+            assert.strictEqual(g.length, 2);
+            assert.strictEqual(g[0], g1);
+            assert.strictEqual(g[0].dependsOn.length, 0);
+            assert.strictEqual(g[1].uniqueName, g2.uniqueName);
+            assert.strictEqual(g[1].dependsOn[0], g1);
+        });
+
+        it("should convert two concurrent goals", () => {
+            const gd: GoalData = {
+                test: {
+                    goals: [[g1, g2]],
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 1);
+            const gc: any = gcs[0];
+            assert.strictEqual(gc.goalsName, "test");
+            const g = gc.staticValue.goals;
+            assert.strictEqual(g.length, 2);
+            assert.strictEqual(g[0], g1);
+            assert.strictEqual(g[0].dependsOn.length, 0);
+            assert.strictEqual(g[1], g2);
+            assert.strictEqual(g[1].dependsOn.length, 0);
+        });
+
+        it("should convert three goals", () => {
+            const gd: GoalData = {
+                test: {
+                    goals: [
+                        [g1, g2],
+                        g3,
+                    ],
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 1);
+            const gc: any = gcs[0];
+            assert.strictEqual(gc.goalsName, "test");
+            const g = gc.staticValue.goals;
+            assert.strictEqual(g.length, 3);
+            assert.strictEqual(g[0], g1);
+            assert.strictEqual(g[0].dependsOn.length, 0);
+            assert.strictEqual(g[1], g2);
+            assert.strictEqual(g[1].dependsOn.length, 0);
+            assert.strictEqual(g[2].uniqueName, g3.uniqueName);
+            assert.strictEqual(g[2].dependsOn.length, 2);
+            assert.strictEqual(g[2].dependsOn[0], g1);
+            assert.strictEqual(g[2].dependsOn[1], g2);
+        });
+
+        it("should convert single goals in two sets", () => {
+            const gd: GoalData = {
+                test1: {
+                    goals: g1,
+                },
+                test2: {
+                    goals: g2,
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 2);
+            const gc1: any = gcs[0];
+            const gs1 = gc1.staticValue.goals;
+            assert.strictEqual(gs1.length, 1);
+            assert.strictEqual(gs1[0], g1);
+
+            const gc2: any = gcs[1];
+            const gs2 = gc2.staticValue.goals;
+            assert.strictEqual(gs2.length, 1);
+            assert.strictEqual(gs2[0], g2);
+        });
+
+        it("should convert single goals in two sets with a set dependency", () => {
+            const gd: GoalData = {
+                test1: {
+                    goals: g1,
+                },
+                test2: {
+                    dependsOn: "test1",
+                    goals: g2,
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 2);
+            const gc1: any = gcs[0];
+            const gs1 = gc1.staticValue.goals;
+            assert.strictEqual(gs1.length, 1);
+            assert.strictEqual(gs1[0], g1);
+
+            const gc2: any = gcs[1];
+            const gs2 = gc2.staticValue.goals;
+            assert.strictEqual(gs2.length, 1);
+            assert.strictEqual(gs2[0].uniqueName, g2.uniqueName);
+            assert.strictEqual(gs2[0].dependsOn.length, 1);
+            assert.strictEqual(gs2[0].dependsOn[0], g1);
+        });
+
+        it("should convert single goals in two sets with a goal dependency", () => {
+            const gd: GoalData = {
+                test1: {
+                    goals: g1,
+                },
+                test2: {
+                    dependsOn: g1,
+                    goals: g2,
+                },
+            };
+
+            const gcs = convertGoalData(gd);
+            assert(!!gcs);
+            assert.strictEqual(gcs.length, 2);
+            const gc1: any = gcs[0];
+            const gs1 = gc1.staticValue.goals;
+            assert.strictEqual(gs1.length, 1);
+            assert.strictEqual(gs1[0], g1);
+
+            const gc2: any = gcs[1];
+            const gs2 = gc2.staticValue.goals;
+            assert.strictEqual(gs2.length, 1);
+            assert.strictEqual(gs2[0].uniqueName, g2.uniqueName);
+            assert.strictEqual(gs2[0].dependsOn.length, 1);
+            assert.strictEqual(gs2[0].dependsOn[0], g1);
+        });
+
+        it("should raise error when set dependency does not exist", () => {
+            const gd: GoalData = {
+                test1: {
+                    goals: g1,
+                },
+                test2: {
+                    dependsOn: "test3",
+                    goals: g2,
+                },
+            };
+
+            try {
+                convertGoalData(gd);
+                assert.fail();
+            } catch (e) {
+                assert.strictEqual(
+                    e.message,
+                    "Provided dependsOn goals with name 'test3' do not exist or is after current goals named 'test2'");
+            }
+        });
+
+        it("should raise error when set dependency is in wrong order", () => {
+            const gd: GoalData = {
+                test2: {
+                    dependsOn: "test1",
+                    goals: g2,
+                },
+                test1: {
+                    goals: g1,
+                },
+            };
+
+            try {
+                convertGoalData(gd);
+                assert.fail();
+            } catch (e) {
+                assert.strictEqual(
+                    e.message,
+                    "Provided dependsOn goals with name 'test1' do not exist or is after current goals named 'test2'");
+            }
+        });
+
+    });
+});


### PR DESCRIPTION
This now supports defining and configuring an SDM in the following way:

```typescript
export const configuration = configure(async sdm => {

    sdm.addExtensionPacks(...)
    
    sdm.addCommand(...);
    
    const mvnBuildJdk8 = new Container({ displayName: "Maven JDK8" })
        .with({
            container: {
                name: "mvn",
                image: "maven:3.3-jdk-8",
                command: ["mvn"],
                args: ["clean", "install", "-B", "-DskipTests=true"],
            },
            output: ["target/*.jar"],
        });

    const kanikoBuild = new Container({ displayName: "Kaniko" })
        .with({
            container: {
                name: "kaniko",
                image: "gcr.io/kaniko-project/executor:latest",
                args: [
                    "--dockerfile=Dockerfile",
                    "--context=dir://atm/home",
                    "--no-push",
                    "--single-snapshot",
                ],
            },
            input: ["target/*.jar"],
        });

    return {
        build: {
            test: hasFile("pom.xml"),
            goals: [
                mvnBuildJdk8,
            ],
        },
        docker_build: {
            test: [hasFile("Dockerfile"), ToDefaultBranch]
            dependsOn: "build",
            goals: kanikoBuild,
        },
    };
});

```

Note: the special `Container` goal comes in separately. 