### PR TITLE
Replace process.exit with safeExit

### DIFF
--- a/lib/graphql/mutation/DeleteTeamConfiguration.graphql
+++ b/lib/graphql/mutation/DeleteTeamConfiguration.graphql
@@ -1,12 +1,6 @@
-mutation DeleteTeamConfiguration(
-    $namespace: String!
-    $name: String!
-) {
-    deleteTeamConfiguration(
-        namespace: $namespace
-        name: $name
-    ) {
-        name
-        namespace
-    }
+mutation DeleteTeamConfiguration($namespace: String!, $name: String!) {
+  deleteTeamConfiguration(namespace: $namespace, name: $name) {
+    name
+    namespace
+  }
 }

--- a/lib/internal/artifact/github/GitHubReleaseArtifactStore.ts
+++ b/lib/internal/artifact/github/GitHubReleaseArtifactStore.ts
@@ -42,6 +42,8 @@ import {
     Tag,
 } from "../../../util/github/ghub";
 
+/* tslint:disable:deprecation */
+
 /**
  * Implement ArtifactStore interface to store artifacts as GitHub releases
  * @deprecated Artifact storage should be done using project listeners

--- a/lib/internal/artifact/local/EphemeralLocalArtifactStore.ts
+++ b/lib/internal/artifact/local/EphemeralLocalArtifactStore.ts
@@ -22,6 +22,8 @@ import {
     StoredArtifact,
 } from "@atomist/sdm";
 
+/* tslint:disable:deprecation */
+
 /**
  * Store the artifact on local disk, relying on in memory cache.
  * **This is purely for demo and test use. It is NOT a production

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "@atomist/automation-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.5.0.tgz",
-      "integrity": "sha512-YnBpHDV3jaCYWzyhMspyZNZzxoE7id2GLDVqIKO3MzKUvSnIQOJpVDT8Nj/3hNXK0foNO2rgUTbOkBuq6+lZqQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.5.1.tgz",
+      "integrity": "sha512-VUsqD33PdyzmTgFchrfbPRfGXn7YTbXXw2yE4UZ1euvnDuU8NfjI7N2ooCY1qf2Q+3+9miabEC/vJYsdAfcEAA==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^1.2.0",
@@ -115,11 +115,11 @@
         "glob-promise": "^3.4.0",
         "glob-stream": "^6.1.0",
         "graphql": "~14.2.1",
-        "graphql-code-generator": "^0.16.1",
-        "graphql-codegen-core": "^0.16.1",
-        "graphql-codegen-typescript-client": "^0.16.1",
-        "graphql-codegen-typescript-common": "^0.16.1",
-        "graphql-codegen-typescript-server": "^0.16.1",
+        "graphql-code-generator": "^0.18.2",
+        "graphql-codegen-core": "^0.18.2",
+        "graphql-codegen-typescript-client": "^0.18.2",
+        "graphql-codegen-typescript-common": "^0.18.2",
+        "graphql-codegen-typescript-server": "^0.18.2",
         "graphql-tag": "2.10.1",
         "heavy": "^6.1.2",
         "helmet": "^3.18.0",
@@ -172,18 +172,6 @@
           "requires": {
             "@types/node": "*"
           }
-        },
-        "@types/lodash": {
-          "version": "4.14.132",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
-          "integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw==",
-          "dev": true
-        },
-        "@types/node": {
-          "version": "12.0.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
-          "dev": true
         },
         "@types/shelljs": {
           "version": "0.8.5",
@@ -303,9 +291,9 @@
           }
         },
         "semver": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
-          "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
           "dev": true
         },
         "source-map": {
@@ -350,12 +338,6 @@
           "requires": {
             "tmp": "0.1.0"
           }
-        },
-        "typescript": {
-          "version": "3.4.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
-          "dev": true
         },
         "ws": {
           "version": "7.0.0",
@@ -856,9 +838,9 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.0.tgz",
-      "integrity": "sha512-w1fCz0bpg1ukbYKLxQn3cYQS9hiqNgmFhlqAqqfr1k0ijMhA/g8Z+7mshiFs1w7OsxxnKhmRxPn7EZR4EJcemA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.1.tgz",
+      "integrity": "sha512-0OavFuLj6FBTdZDD6DXdNqH4qdLFLQD/PKK1OvNZhUd4/5v/lp6Ftzilwmirf549naNHq0u15uk1YCBvym5tNQ==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
@@ -1210,9 +1192,9 @@
       "dev": true
     },
     "@types/babylon": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.4.tgz",
-      "integrity": "sha512-8dZMcGPno3g7pJ/d0AyJERo+lXh9i1JhDuCUs+4lNIN9eUe5Yh6UCLrpgSEi05Ve2JMLauL2aozdvKwNL0px1Q==",
+      "version": "6.16.5",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
+      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
       "requires": {
         "@types/babel-types": "*"
@@ -1507,9 +1489,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.15.2.tgz",
-      "integrity": "sha512-XIB0ZCaFZmWUHAa9dBqP5UKXXHwuukmVlP+XcyU94dui2k+l2lG+CHAbt2ffenHPUqoIs5Beh8Pdf2YEq/CZ7A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.1.tgz",
+      "integrity": "sha512-db6pZL5QY3JrlCHBhYQzYDci0xnoDuxfseUuguLRr3JNk+bnCfpkK6p8quiUDyO8A0vbpBKkk59Fw125etrNeA==",
       "dev": true
     },
     "@types/promise-retry": {
@@ -1775,14 +1757,6 @@
       "requires": {
         "@types/node": "^12.0.2",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.0.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
-          "dev": true
-        }
       }
     },
     "JSONSelect": {
@@ -1842,6 +1816,24 @@
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
+      }
+    },
+    "aggregate-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-2.1.0.tgz",
+      "integrity": "sha512-rIZJqC4XACGWwmPpi18IhDjIzXTJ93KQwYHXuyMCa0Ak9mtzLIbykuei+0i5EnGDy6ts8JVnSyRnZc2cVIMvVg==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^3.0.0"
+      },
+      "dependencies": {
+        "clean-stack": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+          "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -1906,6 +1898,17 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "apollo": {
@@ -3000,24 +3003,23 @@
       }
     },
     "chokidar": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+      "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.0"
       },
       "dependencies": {
         "is-glob": {
@@ -3310,9 +3312,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "concat-map": {
@@ -5635,42 +5637,42 @@
       }
     },
     "graphql-code-generator": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.16.1.tgz",
-      "integrity": "sha512-vp3GKilitpUtiOgJUBk7RhcYtFwy/OffR65mt9NCxeUQr5uDXR3dsb87Na+/opyiobE5JR/P3h6tG01i0G8+CA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/graphql-code-generator/-/graphql-code-generator-0.18.2.tgz",
+      "integrity": "sha512-9ifA5T6hM6qo3RVQz7oYld1R6XYyglT/TanYDoweVEX+6iLxgi0rvGFjFcQ45bPDgLyVkQ9LEsEJuL1YxFmrDw==",
       "dev": true,
       "requires": {
-        "@types/babylon": "6.16.4",
+        "@types/babylon": "6.16.5",
         "@types/is-glob": "4.0.0",
-        "@types/prettier": "1.15.2",
+        "@types/prettier": "1.16.1",
         "@types/valid-url": "1.0.2",
         "babel-types": "7.0.0-beta.3",
         "babylon": "7.0.0-beta.47",
         "chalk": "2.4.2",
         "change-case": "3.1.0",
-        "chokidar": "2.0.4",
+        "chokidar": "2.1.2",
         "commander": "2.19.0",
         "common-tags": "1.8.0",
         "detect-indent": "5.0.0",
         "glob": "7.1.3",
-        "graphql-codegen-core": "0.16.1",
+        "graphql-codegen-core": "0.18.2",
         "graphql-config": "2.2.1",
         "graphql-import": "0.7.1",
-        "graphql-tag-pluck": "0.5.0",
-        "graphql-toolkit": "0.0.5",
+        "graphql-tag-pluck": "0.6.0",
+        "graphql-toolkit": "0.2.0",
         "graphql-tools": "4.0.4",
         "indent-string": "3.2.0",
         "inquirer": "6.2.2",
         "is-glob": "4.0.0",
         "is-valid-path": "0.1.1",
-        "js-yaml": "3.12.1",
+        "js-yaml": "3.13.1",
         "json-to-pretty-yaml": "1.2.2",
         "listr": "0.14.3",
         "listr-update-renderer": "0.5.0",
         "log-symbols": "2.2.0",
         "log-update": "2.3.0",
         "mkdirp": "0.5.1",
-        "prettier": "1.16.3",
+        "prettier": "1.16.4",
         "request": "2.88.0",
         "valid-url": "1.0.9"
       },
@@ -5721,9 +5723,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.12.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-          "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -5740,9 +5742,9 @@
           }
         },
         "prettier": {
-          "version": "1.16.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-          "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+          "version": "1.16.4",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+          "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
           "dev": true
         },
         "strip-ansi": {
@@ -5757,61 +5759,61 @@
       }
     },
     "graphql-codegen-core": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.16.1.tgz",
-      "integrity": "sha512-KtvZqvB6no+vPtkIYpYpVSCclT0zfqSVCDZXTYu4GiMV2RdI7C+2/WMhDGPXEj5xwb6jDWaYH23BqiN3kObtrw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-core/-/graphql-codegen-core-0.18.2.tgz",
+      "integrity": "sha512-fjfIUrDx0KDdr/jYjUs51+07DvcEc5w9tdid/bNezNzT2iJLtmnnmYLR62an3/PKUnKSOAIKLYxFIBOzsFJH9A==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",
         "change-case": "3.1.0",
         "common-tags": "1.8.0",
         "graphql-tag": "2.10.1",
-        "graphql-toolkit": "0.0.5",
+        "graphql-toolkit": "0.2.0",
         "graphql-tools": "4.0.4",
         "ts-log": "2.1.4",
         "winston": "3.2.1"
       }
     },
     "graphql-codegen-plugin-helpers": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-plugin-helpers/-/graphql-codegen-plugin-helpers-0.16.1.tgz",
-      "integrity": "sha512-VlNOBUoa9u1s0qk1nI7xQYNvQLQNv/XeVaEKIwzxZ9s5UmXYePIABnYzerSXfb8o4zasuQ/7TLvVQn6zqw30pQ==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-plugin-helpers/-/graphql-codegen-plugin-helpers-0.18.2.tgz",
+      "integrity": "sha512-WZahfp95RdePwwPWxnxAHgfkXXEQXNrgX9sGrB//uGfj8lygcf7m/rNZQ4iooUzoqBEkTtJpi7bezWCieNcq2A==",
       "dev": true,
       "requires": {
-        "graphql-codegen-core": "0.16.1",
+        "graphql-codegen-core": "0.18.2",
         "import-from": "2.1.0"
       }
     },
     "graphql-codegen-typescript-client": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-typescript-client/-/graphql-codegen-typescript-client-0.16.1.tgz",
-      "integrity": "sha512-6y6+k6HzN/5il0q6qH3uYPiOe0URp+Iw/ChhRlMM7UupU26nGCT/lABlI/mIOVMHLUmMlecZY6v0GvYhe+8zkA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-typescript-client/-/graphql-codegen-typescript-client-0.18.2.tgz",
+      "integrity": "sha512-HffKYPrT5jGIRTiWCTst/X3EBpuOHsheI5tKUEf9NfrR8ySWs6PfqZO5fKCFWZOqC9xn7Y75jFXaeH8tgV5y1g==",
       "dev": true,
       "requires": {
-        "graphql-codegen-core": "0.16.1",
-        "graphql-codegen-plugin-helpers": "0.16.1",
-        "graphql-codegen-typescript-common": "0.16.1"
+        "graphql-codegen-core": "0.18.2",
+        "graphql-codegen-plugin-helpers": "0.18.2",
+        "graphql-codegen-typescript-common": "0.18.2"
       }
     },
     "graphql-codegen-typescript-common": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-typescript-common/-/graphql-codegen-typescript-common-0.16.1.tgz",
-      "integrity": "sha512-WBNGYu84qJ7r677/nEGzERWmbIuHIFTp17MfmOXjh0zJHHmfBapEb7jqjYxDGw7/VVM5SaLDAYddjaU3AvpbPg==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-typescript-common/-/graphql-codegen-typescript-common-0.18.2.tgz",
+      "integrity": "sha512-uGGHd/vgwMlnCNOMQkvMxW8Xz0fqPGjPHROsniRNP1ragsa6KfFBrGu9toHgxv8m3MzC6ZPeoUa3wtwtS9oVnA==",
       "dev": true,
       "requires": {
         "change-case": "3.1.0",
         "common-tags": "1.8.0",
-        "graphql-codegen-core": "0.16.1",
-        "graphql-codegen-plugin-helpers": "0.16.1"
+        "graphql-codegen-core": "0.18.2",
+        "graphql-codegen-plugin-helpers": "0.18.2"
       }
     },
     "graphql-codegen-typescript-server": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/graphql-codegen-typescript-server/-/graphql-codegen-typescript-server-0.16.1.tgz",
-      "integrity": "sha512-AWetg8DchXfEfqoN1OrgmIM5R7fo9fZKtBruoVmrjb2FXCUWkb1wAxAdSPraMBXn/pGk8rtfq4G9BJ86KK5HZQ==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/graphql-codegen-typescript-server/-/graphql-codegen-typescript-server-0.18.2.tgz",
+      "integrity": "sha512-1marSv3TCry6IsQd+Hdarq/AhDpgJ3Yg+e9Or3Urv7Fkw4YbhtyGp6AkpBK+DMKlyKFPjpLnmjAaHS3hjrCp3Q==",
       "dev": true,
       "requires": {
-        "graphql-codegen-typescript-common": "0.16.1"
+        "graphql-codegen-typescript-common": "0.18.2"
       }
     },
     "graphql-config": {
@@ -5861,9 +5863,9 @@
       "dev": true
     },
     "graphql-tag-pluck": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag-pluck/-/graphql-tag-pluck-0.5.0.tgz",
-      "integrity": "sha512-SlsIpXKbrKIV2+QxYZ7bFPQ0DpIXFd0BEz3U+Krt8tuHYMFtElcctNDppW4EeQTrSX9H5zpStBZyfOYQjQOH1w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag-pluck/-/graphql-tag-pluck-0.6.0.tgz",
+      "integrity": "sha512-C1SRw5zZtl7CN7mv6Q0abFVSJwG8M+FniFCPqWD+AjQMj9igNPthraMUQ02KSo+j19khR60mksqmFN3BwboFaw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.2.0",
@@ -5874,28 +5876,24 @@
       }
     },
     "graphql-toolkit": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/graphql-toolkit/-/graphql-toolkit-0.0.5.tgz",
-      "integrity": "sha512-655RP1y8cn65mOa9EE/jnttczHE0lFXpOV1zYLTsE1A0b5j8RVuKWllSZBnnL2WHSAPPqLZ1oJEZV2uzSdV9VQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-toolkit/-/graphql-toolkit-0.2.0.tgz",
+      "integrity": "sha512-dMwb+V2u6vwJF70tWuqSxgNal9fK1xcB8JtmCJUStVUh+PjfNrlKH1X5e17vJlN+lRPz1hatr8jH+Q6lTW0jLw==",
       "dev": true,
       "requires": {
-        "deepmerge": "3.1.0",
+        "aggregate-error": "2.1.0",
+        "deepmerge": "3.2.0",
         "glob": "7.1.3",
         "graphql-import": "0.7.1",
-        "graphql-tag-pluck": "0.5.0",
+        "graphql-tag-pluck": "0.6.0",
         "is-glob": "4.0.0",
         "is-valid-path": "0.1.1",
         "lodash": "4.17.11",
         "request": "2.88.0",
+        "tslib": "^1.9.3",
         "valid-url": "1.0.9"
       },
       "dependencies": {
-        "deepmerge": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
-          "integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg==",
-          "dev": true
-        },
         "is-glob": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -8156,13 +8154,10 @@
       }
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "normalize-url": {
       "version": "2.0.1",
@@ -10989,9 +10984,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "ts-essentials": "^1.0.2"
   },
   "peerDependencies": {
-    "@atomist/automation-client": ">=1.5.0",
+    "@atomist/automation-client": ">=1.5.1",
     "@atomist/sdm": ">=1.5.0",
     "@atomist/slack-messages": ">=1.1.0",
     "@atomist/tree-path": ">=1.0.3",
     "@atomist/microgrammar": ">=1.2.0"
   },
   "devDependencies": {
-    "@atomist/automation-client": "^1.5.0",
+    "@atomist/automation-client": "^1.5.1",
     "@atomist/sdm": "^1.5.0",
     "@atomist/slack-messages": "^1.1.0",
     "@types/lodash": "^4.14.132",


### PR DESCRIPTION
Allow shutdown hooks to be run by replacing process.exit calls with
safeExit.

Fix handling of handler result promise in GoalAutomationEventListener.

Delint.

Upgrade to @atomist/automation-client@1.5.1.