### PR TITLE
Add container goal

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,26 @@ export {
     ProjectVersionerRegistration,
 } from "./lib/goal/common/Version";
 export {
+    Container,
+    containerGoal,
+    ContainerPort,
+    ContainerProjectHome,
+    ContainerRegistration,
+    ContainerScheduler,
+    ContainerSpecCallback,
+    ContainerVolumeMount,
+    GoalContainer,
+    GoalContainerVolume,
+} from "./lib/goal/container/container";
+export {
+    DockerContainerRegistration,
+} from "./lib/goal/container/docker";
+export {
+    K8sContainerRegistration,
+    K8sContainerSpecCallback,
+    K8sGoalContainerSpec,
+} from "./lib/goal/container/k8s";
+export {
     DisplayDeployEnablement,
 } from "./lib/handlers/commands/DisplayDeployEnablement";
 export {

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ export {
 } from "./lib/goal/common/Version";
 export {
     Container,
-    containerGoal,
+    container,
     ContainerPort,
     ContainerProjectHome,
     ContainerRegistration,

--- a/lib/goal/cache/goalCaching.ts
+++ b/lib/goal/cache/goalCaching.ts
@@ -139,7 +139,7 @@ export function cachePut(options: GoalCacheOptions,
         listener: async (p: GitProject,
                          gi: GoalInvocation): Promise<void | ExecuteGoalResult> => {
             if (!!isCacheEnabled(gi)) {
-                const goalCache = (gi.configuration.sdm.goalCache || DefaultGoalCache) as GoalCache;
+                const goalCache = cacheStore(gi);
                 const entries = !!classifier ?
                     options.entries.filter(pattern => allClassifiers.includes(pattern.classifier)) :
                     options.entries;
@@ -221,7 +221,7 @@ export function cacheRestore(options: GoalCacheRestoreOptions,
                          gi: GoalInvocation,
                          event: GoalProjectListenerEvent): Promise<void | ExecuteGoalResult> => {
             if (!!isCacheEnabled(gi)) {
-                const goalCache = (gi.configuration.sdm.goalCache || DefaultGoalCache) as GoalCache;
+                const goalCache = cacheStore(gi);
                 const classifiersToBeRestored = [];
                 if (allClassifiers.length > 0) {
                     classifiersToBeRestored.push(...allClassifiers);
@@ -263,7 +263,7 @@ export function cacheRemove(options: GoalCacheOptions,
         name: listenerName,
         listener: async (p, gi) => {
             if (!!isCacheEnabled(gi)) {
-                const goalCache = (gi.configuration.sdm.goalCache || DefaultGoalCache) as GoalCache;
+                const goalCache = cacheStore(gi);
                 const classifiersToBeRemoved = [];
                 if (allClassifiers.length > 0) {
                     classifiersToBeRemoved.push(...allClassifiers);
@@ -286,4 +286,10 @@ async function getFilePathsThroughPattern(project: Project, globPattern: string 
 
 function isCacheEnabled(gi: GoalInvocation): boolean {
     return _.get(gi.configuration, "sdm.cache.enabled", false);
+}
+
+function cacheStore(gi: GoalInvocation): GoalCache {
+    const store: GoalCache = _.get(gi.configuration, "sdm.cache.store",
+        gi.configuration.sdm.goalCache || DefaultGoalCache);
+    return store;
 }

--- a/lib/goal/container/container.ts
+++ b/lib/goal/container/container.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitProject,
+    HandlerContext,
+} from "@atomist/automation-client";
+import {
+    DefaultGoalNameGenerator,
+    FulfillableGoalDetails,
+    FulfillableGoalWithRegistrations,
+    Fulfillment,
+    getGoalDefinitionFrom,
+    Goal,
+    GoalFulfillmentCallback,
+    ImplementationRegistration,
+    SdmGoalEvent,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
+import {
+    isConfiguredInEnv,
+    KubernetesGoalScheduler,
+} from "../../pack/k8s/KubernetesGoalScheduler";
+import { KubernetesJobDeletingGoalCompletionListenerFactory } from "../../pack/k8s/KubernetesJobDeletingGoalCompletionListener";
+import { toArray } from "../../util/misc/array";
+import {
+    CacheEntry,
+    cachePut,
+    cacheRestore,
+} from "../cache/goalCaching";
+import { dockerContainerScheduler } from "./docker";
+import { k8sContainerScheduler } from "./k8s";
+import { runningInK8s } from "./util";
+
+/**
+ * Create and return a container goal with the provided container
+ * specification.
+ *
+ * @param displayName Goal display name
+ * @param registration Goal containers, volumes, cache details, etc.
+ * @return SDM container goal
+ */
+export function containerGoal(displayName: string, registration: ContainerRegistration): Container {
+    return new Container({ displayName }).with(registration);
+}
+
+/**
+ * Ports to expose from container.
+ */
+export interface ContainerPort {
+    /**
+     * Number of port to expose from the container. This must be
+     * a valid port number, 0 < x < 65536.
+     */
+    containerPort: number;
+}
+
+/**
+ * Volumes to mount in container.
+ */
+export interface ContainerVolumeMount {
+    /** Path to mount point of volume. */
+    mountPath: string;
+    /** Name of volume from [[GoalContainer.volumes]]. */
+    name: string;
+}
+
+/**
+ * Simplified container abstraction for goals.
+ */
+export interface GoalContainer {
+    /** Unique name for this container within this goal. */
+    name: string;
+    /** Full Docker image name, i.e., `registry/name:tag`. */
+    image: string;
+    /**
+     * Docker command and arguments.  We call this `args` rather than
+     * `command` because we think k8s got it right.
+     */
+    args?: string[];
+    /**
+     * Docker image entrypoint.  We call this `command` rather than
+     * `entrypoint` because we think k8s got it right.
+     */
+    command?: string[];
+    /**
+     * Environment variables to set in Docker container.
+     */
+    env?: Array<{ name: string, value: string }>;
+    /**
+     * Ports to expose from container.
+     */
+    ports?: ContainerPort[];
+    /**
+     * Volumes to mount in container.
+     */
+    volumeMounts?: ContainerVolumeMount[];
+}
+
+/**
+ * Volumes that containers in goal can mount.
+ */
+export interface GoalContainerVolume {
+    /** Volume to be created from local host file system location. */
+    hostPath: {
+        /** Absolute path on host to volume. */
+        path: string;
+    };
+    /** Unique name of volume, referenced by [[ContainerVolumeMount.name]]. */
+    name: string;
+}
+
+/**
+ * File system location of goal project in containers.
+ */
+export const ContainerProjectHome = "/atm/home";
+
+/**
+ * Specification of containers and volumes for a container goal.
+ */
+export interface GoalContainerSpec {
+    /**
+     * Containers to run for this goal.  The goal result is based on
+     * the exit status of the first element of the `containers` array.
+     * The other containers are considered "sidecar" containers
+     * provided functionality that the main container needs to
+     * function.  The working directory of the first container is set
+     * to [[ContainerProjectHome]], which contains the project upon
+     * which the goal should operate.
+     */
+    containers: GoalContainer[];
+    /**
+     * Volumes available to mount in containers.
+     */
+    volumes?: GoalContainerVolume[];
+}
+
+/**
+ * Function signature for callback that can modify and return the
+ * [[ContainerRegistration]] object.
+ */
+export type ContainerSpecCallback =
+    (r: ContainerRegistration, p: GitProject, g: Container, e: SdmGoalEvent, c: HandlerContext) => Promise<GoalContainerSpec>;
+
+/**
+ * Container goal artifacts and implementations information.
+ */
+export interface ContainerRegistration extends Partial<ImplementationRegistration>, GoalContainerSpec {
+    /**
+     * Callback function to dynamically modify the goal container spec
+     * when goal is executed.
+     */
+    callback?: ContainerSpecCallback;
+    /**
+     * Cache classifiers to retrieve from cache before starting goal
+     * execution.  The values must correspond to output classifiers
+     * from previously executed container goals in the same goal set.
+     */
+    input?: string[];
+    /**
+     * File path globs to store in cache after goal execution.
+     * They values should be glob paths relative to the root of
+     * the project directory.
+     */
+    output?: CacheEntry[];
+}
+
+/**
+ * Container goal scheduler implementation.  The goal execution is
+ * handled as part of the execution of the container.
+ */
+export type ContainerScheduler = (goal: Container, registration: ContainerRegistration) => void;
+
+export interface ContainerGoalDetails extends FulfillableGoalDetails {
+    /**
+     * Container goal scheduler.  If no scheduler is provided, the k8s
+     * scheduler is used if the SDM is running in a Kubernetes
+     * cluster, otherwise the Docker scheduler is used.
+     */
+    scheduler?: ContainerScheduler;
+}
+
+/**
+ * Goal run as a container, as seen on TV.
+ */
+export class Container extends FulfillableGoalWithRegistrations<ContainerRegistration> {
+
+    public readonly details: ContainerGoalDetails;
+
+    constructor(details: ContainerGoalDetails = {}, ...dependsOn: Goal[]) {
+        const prefix = "container" + (details.displayName ? `-${details.displayName}` : "");
+        super(getGoalDefinitionFrom(details, DefaultGoalNameGenerator.generateName(prefix)), ...dependsOn);
+        this.details = details;
+    }
+
+    public register(sdm: SoftwareDeliveryMachine): void {
+        super.register(sdm);
+
+        if (runningInK8s()) {
+            // Make sure that the KubernetesGoalScheduler gets added if needed
+            const goalSchedulers = toArray(sdm.configuration.sdm.goalScheduler) || [];
+            if (!goalSchedulers.some(gs => gs instanceof KubernetesGoalScheduler)) {
+                if (!process.env.ATOMIST_ISOLATED_GOAL && isConfiguredInEnv("kubernetes", "kubernetes-all")) {
+                    sdm.configuration.sdm.goalScheduler = [...goalSchedulers, new KubernetesGoalScheduler()];
+                    sdm.addGoalCompletionListener(new KubernetesJobDeletingGoalCompletionListenerFactory(sdm).create());
+                }
+            }
+        }
+    }
+
+    public with(registration: ContainerRegistration): this {
+        if (!this.details.scheduler) {
+            if (runningInK8s()) {
+                this.details.scheduler = k8sContainerScheduler;
+            } else {
+                this.details.scheduler = dockerContainerScheduler;
+            }
+        }
+        this.details.scheduler(this, registration);
+        if (registration.input && registration.input.length > 0) {
+            this.withProjectListener(cacheRestore({ entries: registration.input.map(c => ({ classifier: c })) }));
+        }
+        if (registration.output && registration.output.length > 0) {
+            this.withProjectListener(cachePut({ entries: registration.output }));
+        }
+        return this;
+    }
+
+    public addFulfillment(fulfillment: Fulfillment): this {
+        return super.addFulfillment(fulfillment);
+    }
+
+    public addFulfillmentCallback(cb: GoalFulfillmentCallback): this {
+        return super.addFulfillmentCallback(cb);
+    }
+}

--- a/lib/goal/container/container.ts
+++ b/lib/goal/container/container.ts
@@ -53,7 +53,7 @@ import { runningInK8s } from "./util";
  * @param registration Goal containers, volumes, cache details, etc.
  * @return SDM container goal
  */
-export function containerGoal(displayName: string, registration: ContainerRegistration): Container {
+export function container<T extends ContainerRegistration>(displayName: string, registration: T): Container {
     return new Container({ displayName }).with(registration);
 }
 

--- a/lib/goal/container/docker.ts
+++ b/lib/goal/container/docker.ts
@@ -1,0 +1,319 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    guid,
+    logger,
+} from "@atomist/automation-client";
+import {
+    DefaultGoalNameGenerator,
+    doWithProject,
+    ExecuteGoal,
+    ImplementationRegistration,
+    spawnLog,
+    SpawnLogOptions,
+    SpawnLogResult,
+} from "@atomist/sdm";
+import * as fs from "fs-extra";
+import * as stringify from "json-stringify-safe";
+import * as _ from "lodash";
+import * as os from "os";
+import * as path from "path";
+import {
+    Container,
+    ContainerProjectHome,
+    ContainerRegistration,
+    ContainerScheduler,
+    GoalContainer,
+    GoalContainerSpec,
+} from "./container";
+import {
+    containerEnvVars,
+    copyProject,
+    loglog,
+} from "./util";
+
+/**
+ * Additional options for Docker CLI implementation of container goals.
+ */
+export interface DockerContainerRegistration extends ContainerRegistration {
+    /** Additional Docker CLI command-line options. */
+    dockerOptions?: string[];
+}
+
+export const dockerContainerScheduler: ContainerScheduler = (goal, registration: DockerContainerRegistration) => {
+    goal.addFulfillment({
+        goalExecutor: executeDockerJob(goal, registration),
+        name: DefaultGoalNameGenerator.generateName(`container-docker-${goal.definition.displayName}`),
+        ...registration as ImplementationRegistration,
+    });
+};
+
+interface SpawnedContainer {
+    name: string;
+    promise: Promise<SpawnLogResult>;
+}
+
+/**
+ * Execute container goal using Docker CLI.  Wait on completion of
+ * first container, then kill all the rest.
+ */
+export function executeDockerJob(goal: Container, registration: DockerContainerRegistration): ExecuteGoal {
+    return doWithProject(async gi => {
+        const { goalEvent, progressLog, project } = gi;
+
+        const spec: GoalContainerSpec = _.merge({}, { containers: registration.containers, volumes: registration.volumes },
+            (registration.callback) ? await registration.callback(registration, project, goal, goalEvent, gi.context) : {});
+
+        if (!spec.containers || spec.containers.length < 1) {
+            throw new Error("No containers defined in GoalContainerSpec");
+        }
+
+        const goalName = goalEvent.uniqueName.split("#")[0].toLowerCase();
+        const namePrefix = "sdm-";
+        const nameSuffix = `-${goalEvent.goalSetId.slice(0, 7)}-${goalName}`;
+
+        const projectDir = project.baseDir;
+        const containerDir = path.join(os.homedir(), ".atomist", "tmp", project.id.owner, project.id.repo, goalEvent.goalSetId,
+            `${namePrefix}tmp-${guid()}${nameSuffix}`);
+        try {
+            await copyProject(projectDir, containerDir);
+        } catch (e) {
+            const message = `Failed to duplicate project directory for goal ${goalName}: ${e.message}`;
+            loglog(message, logger.error, progressLog);
+            return { code: 1, message };
+        }
+
+        const spawnOpts = {
+            log: progressLog,
+            cwd: containerDir,
+        };
+
+        const network = `${namePrefix}network-${guid()}${nameSuffix}`;
+        const networkCreateRes = await spawnLog("docker", ["network", "create", network], spawnOpts);
+        if (networkCreateRes.code) {
+            let message = `Failed to create Docker network '${network}'` +
+                ((networkCreateRes.error) ? `: ${networkCreateRes.error.message}` : "");
+            loglog(message, logger.error, progressLog);
+            try {
+                await dockerCleanup({ containerDir, projectDir, spawnOpts });
+            } catch (e) {
+                networkCreateRes.code++;
+                message += `; ${e.message}`;
+            }
+            return { code: networkCreateRes.code, message };
+        }
+
+        const atomistEnvs = (await containerEnvVars(gi.goalEvent, gi)).map(env => `--env=${env.name}=${env.value}`);
+
+        const spawnedContainers: SpawnedContainer[] = [];
+        const failures: string[] = [];
+        for (const container of spec.containers) {
+            const containerName = `${namePrefix}${container.name}${nameSuffix}`;
+            let containerArgs: string[];
+            try {
+                containerArgs = containerDockerOptions(container, registration);
+            } catch (e) {
+                loglog(e.message, logger.error, progressLog);
+                failures.push(e.message);
+                break;
+            }
+            const dockerArgs = [
+                "run",
+                "-t",
+                "--rm",
+                `--name=${containerName}`,
+                `--volume=${containerDir}:${ContainerProjectHome}`,
+                `--network=${network}`,
+                `--network-alias=${container.name}`,
+                ...containerArgs,
+                ...(registration.dockerOptions || []),
+                ...atomistEnvs,
+                container.image,
+                ...(container.args || []),
+            ];
+            if (spawnedContainers.length < 1) {
+                dockerArgs.splice(5, 0, `-w=${ContainerProjectHome}`);
+            }
+            const promise = spawnLog("docker", dockerArgs, spawnOpts);
+            spawnedContainers.push({ name: containerName, promise });
+        }
+        if (failures.length > 0) {
+            try {
+                await dockerCleanup({ containerDir, network, projectDir, spawnOpts, containers: spawnedContainers });
+            } catch (e) {
+                failures.push(e.message);
+            }
+            return {
+                code: failures.length,
+                message: `Failed to spawn Docker containers: ${failures.join("; ")}`,
+            };
+        }
+
+        const main = spawnedContainers[0];
+        try {
+            const result = await main.promise;
+            if (result.code) {
+                const msg = `Docker container '${main.name}' failed` + ((result.error) ? `: ${result.error.message}` : "");
+                loglog(msg, logger.error, progressLog);
+                failures.push(msg);
+            }
+        } catch (e) {
+            const message = `Failed to execute main Docker container '${main.name}': ${e.message}`;
+            loglog(message, logger.error, progressLog);
+            failures.push(message);
+        }
+
+        const sidecars = spawnedContainers.slice(1);
+        try {
+            await dockerCleanup({ containerDir, network, projectDir, spawnOpts, containers: sidecars });
+        } catch (e) {
+            failures.push(e.message);
+        }
+
+        return {
+            code: failures.length,
+            message: (failures.length > 0) ? failures.join("; ") : "Successfully completed container job",
+        };
+    }, { readOnly: false });
+}
+
+/**
+ * Generate container specific Docker command-line options.
+ *
+ * @param container Goal container spec
+ * @param registration Container goal registration object
+ * @return Docker command-line entrypoint, env, p, and volume options
+ */
+export function containerDockerOptions(container: GoalContainer, registration: ContainerRegistration): string[] {
+    const entryPoint: string[] = [];
+    if (container.command && container.command.length > 0) {
+        // Docker CLI entrypoint must be a binary...
+        entryPoint.push(`--entrypoint=${container.command[0]}`);
+        // ...so prepend any other command elements to args array
+        if (container.args) {
+            container.args.splice(0, 0, ...container.command.slice(1));
+        } else {
+            container.args = container.command.slice(1);
+        }
+    }
+    const envs = (container.env || []).map(env => `--env=${env.name}=${env.value}`);
+    const ports = (container.ports || []).map(port => `-p=${port.containerPort}`);
+    const volumes: string[] = [];
+    for (const vm of (container.volumeMounts || [])) {
+        const volume = (registration.volumes || []).find(v => v.name === vm.name);
+        if (!volume) {
+            const msg = `Container '${container.name}' references volume '${vm.name}' which not provided in goal registration ` +
+                `volumes: ${stringify(registration.volumes)}`;
+            logger.error(msg);
+            throw new Error(msg);
+        }
+        volumes.push(`--volume=${volume.hostPath.path}:${vm.mountPath}`);
+    }
+    return [
+        ...entryPoint,
+        ...envs,
+        ...ports,
+        ...volumes,
+    ];
+}
+
+/**
+ * Docker elements to cleanup after execution.
+ */
+interface CleanupOptions {
+    /**
+     * Project directory created for goal.  Its contents are replaced
+     * with the contents of the [[containerDirectory]].
+     */
+    projectDir: string;
+    /**
+     * Options to use when calling spawnLog.  Also provides the
+     * progress log.
+     */
+    spawnOpts: SpawnLogOptions;
+    /**
+     * Project directory mounted into container.  If it is provided,
+     * its contents are copied to the [[projectDirectory]] and then
+     * the directory is removed.
+     */
+    containerDir?: string;
+    /** Containers to kill by name, if provided. */
+    containers?: SpawnedContainer[];
+    /**
+     * Name of Docker network created for this goal execution.  If
+     * provided, it will be removed.
+     */
+    network?: string;
+}
+
+/**
+ * Kill running Docker containers, then delete network, copy
+ * container's project directory to original project directory, and
+ * remove directory container directory.  If the copy fails, it throws
+ * an error.  Other errors are logged and ignored.
+ *
+ * @param opts See [[CleanupOptions]]
+ */
+async function dockerCleanup(opts: CleanupOptions): Promise<void> {
+    if (opts.containers) {
+        await dockerKill(opts.containers, opts.spawnOpts);
+    }
+    if (opts.network) {
+        const networkDeleteRes = await spawnLog("docker", ["network", "rm", opts.network], opts.spawnOpts);
+        if (networkDeleteRes.code) {
+            const msg = `Failed to delete Docker network '${opts.network}'` +
+                ((networkDeleteRes.error) ? `: ${networkDeleteRes.error.message}` : "");
+            loglog(msg, logger.error, opts.spawnOpts.log);
+        }
+    }
+    if (opts.containerDir) {
+        try {
+            await copyProject(opts.containerDir, opts.projectDir);
+        } catch (e) {
+            e.message = `Failed to update project directory '${opts.projectDir}' with contents from container ` +
+                `directory '${opts.containerDir}': ${e.message}`;
+            loglog(e.message, logger.error, opts.spawnOpts.log);
+            throw e;
+        }
+        try {
+            await fs.remove(opts.containerDir);
+        } catch (e) {
+            const message = `Failed to remove container directory '${opts.containerDir}': ${e.message}`;
+            loglog(message, logger.error, opts.spawnOpts.log);
+        }
+    }
+}
+
+/**
+ * Kill Docker containers.  Any errors are caught and logged, but not
+ * re-thrown.
+ *
+ * @param containers Containers to kill, they will be killed by name
+ * @param opts Options to use when calling spawnLog
+ */
+async function dockerKill(containers: SpawnedContainer[], opts: SpawnLogOptions): Promise<void> {
+    try {
+        const killPromises: Array<Promise<SpawnLogResult>> = [];
+        for (const container of containers) {
+            killPromises.push(spawnLog("docker", ["kill", container.name], opts));
+        }
+        await Promise.all(killPromises);
+    } catch (e) {
+        const message = `Failed to kill Docker containers: ${e.message}`;
+        loglog(message, logger.error, opts.log);
+    }
+}

--- a/lib/goal/container/docker.ts
+++ b/lib/goal/container/docker.ts
@@ -50,7 +50,13 @@ import {
  * Additional options for Docker CLI implementation of container goals.
  */
 export interface DockerContainerRegistration extends ContainerRegistration {
-    /** Additional Docker CLI command-line options. */
+    /**
+     * Additional Docker CLI command-line options.  Command-line
+     * options provided here will be appended to the default set of
+     * options used when executing `docker run`.  For example, if your
+     * main container must run in its default working directory, you
+     * can include `"--workdir="` in the `dockerOptions` array.
+     */
     dockerOptions?: string[];
 }
 
@@ -133,7 +139,7 @@ export function executeDockerJob(goal: Container, registration: DockerContainerR
             }
             const dockerArgs = [
                 "run",
-                "-t",
+                "--tty",
                 "--rm",
                 `--name=${containerName}`,
                 `--volume=${containerDir}:${ContainerProjectHome}`,
@@ -146,7 +152,7 @@ export function executeDockerJob(goal: Container, registration: DockerContainerR
                 ...(container.args || []),
             ];
             if (spawnedContainers.length < 1) {
-                dockerArgs.splice(5, 0, `-w=${ContainerProjectHome}`);
+                dockerArgs.splice(5, 0, `--workdir=${ContainerProjectHome}`);
             }
             const promise = spawnLog("docker", dockerArgs, spawnOpts);
             spawnedContainers.push({ name: containerName, promise });

--- a/lib/goal/container/k8s.ts
+++ b/lib/goal/container/k8s.ts
@@ -1,0 +1,437 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitCommandGitProject,
+    GitProject,
+    HandlerContext,
+    logger,
+} from "@atomist/automation-client";
+import { sleep } from "@atomist/automation-client/lib/internal/util/poll";
+import {
+    DefaultGoalNameGenerator,
+    doWithProject,
+    ExecuteGoal,
+    GoalScheduler,
+    ImplementationRegistration,
+    ProgressLog,
+    RepoContext,
+    SdmGoalEvent,
+    SdmGoalState,
+    ServiceRegistrationGoalDataKey,
+} from "@atomist/sdm";
+import * as k8s from "@kubernetes/client-node";
+import * as stringify from "json-stringify-safe";
+import * as _ from "lodash";
+import * as os from "os";
+import * as request from "request";
+import { Writable } from "stream";
+import {
+    DeepPartial,
+    Merge,
+} from "ts-essentials";
+import { loadKubeConfig } from "../../pack/k8s/config";
+import {
+    k8sJobEnv,
+    KubernetesGoalScheduler,
+    readNamespace,
+} from "../../pack/k8s/KubernetesGoalScheduler";
+import {
+    K8sServiceRegistrationType,
+    K8sServiceSpec,
+} from "../../pack/k8s/service";
+import { toArray } from "../../util/misc/array";
+import {
+    Container,
+    ContainerProjectHome,
+    ContainerRegistration,
+    ContainerScheduler,
+    GoalContainer,
+    GoalContainerVolume,
+} from "./container";
+import {
+    containerEnvVars,
+    copyProject,
+    loglog,
+} from "./util";
+
+/**
+ * Specification of containers and volumes for a container goal.
+ */
+export interface K8sGoalContainerSpec {
+    /**
+     * Containers to run for this goal.  The goal result is based on
+     * the exit status of the first element of the `containers` array.
+     * The other containers are considered "sidecar" containers
+     * provided functionality that the main container needs to
+     * function.  The working directory of the first container is set
+     * to [[ContainerProjectHome]], which contains the project upon
+     * which the goal should operate.
+     */
+    containers: Array<Merge<DeepPartial<k8s.V1Container>, GoalContainer>>;
+    /**
+     * Volumes available to mount in containers.
+     */
+    volumes?: Array<Merge<DeepPartial<k8s.V1Volume>, GoalContainerVolume>>;
+}
+
+/**
+ * Function signature for callback that can modify and return the
+ * [[ContainerRegistration]] object.
+ */
+export type K8sContainerSpecCallback =
+    (r: K8sContainerRegistration, p: GitProject, g: Container, e: SdmGoalEvent, c: HandlerContext) => Promise<K8sGoalContainerSpec>;
+
+/**
+ * Additional options for Kubernetes implementation of container goals.
+ */
+export interface K8sContainerRegistration extends ContainerRegistration {
+    /**
+     * Replace generic containers in [[ContainerRegistration]] with
+     * Kubernetes containers.
+     */
+    containers: Array<Merge<DeepPartial<k8s.V1Container>, GoalContainer>>;
+    /**
+     * Replace generic callback in [[ContainerRegistration]] with
+     * Kubernetes-specific callback.
+     */
+    callback?: K8sContainerSpecCallback;
+    /**
+     * Replace generic volumes in [[ContainerRegistration]] with
+     * Kubernetes volumes.
+     */
+    volumes?: Array<Merge<DeepPartial<k8s.V1Volume>, GoalContainerVolume>>;
+}
+
+export const k8sContainerScheduler: ContainerScheduler = (goal, registration: K8sContainerRegistration) => {
+    goal.addFulfillment({
+        goalExecutor: executeK8sJob(goal, registration),
+        name: DefaultGoalNameGenerator.generateName(`container-k8s-${goal.definition.displayName}`),
+        ...registration as ImplementationRegistration,
+    });
+
+    goal.addFulfillmentCallback({
+        goal,
+        callback: k8sFulfillmentCallback(goal, registration),
+    });
+};
+
+/**
+ * Add Kubernetes job scheduling information to SDM goal event data
+ * for use by the [[KubernetesGoalScheduler]].
+ */
+export function k8sFulfillmentCallback(
+    goal: Container,
+    registration: K8sContainerRegistration,
+): (sge: SdmGoalEvent, rc: RepoContext) => Promise<SdmGoalEvent> {
+
+    return async (goalEvent, repoContext) => {
+        const spec: K8sGoalContainerSpec = _.merge({}, { containers: registration.containers, volumes: registration.volumes });
+        if (registration.callback) {
+            const project = await GitCommandGitProject.cloned(repoContext.credentials, repoContext.id);
+            _.merge(spec, await registration.callback(registration, project, goal, goalEvent, repoContext.context));
+        }
+
+        if (!spec.containers || spec.containers.length < 1) {
+            throw new Error("No containers defined in K8sGoalContainerSpec");
+        }
+
+        spec.containers[0].workingDir = ContainerProjectHome;
+        const containerEnvs = await containerEnvVars(goalEvent, repoContext);
+        spec.containers.forEach(c => {
+            c.env = [
+                ...containerEnvs,
+                ...(c.env || []),
+            ];
+        });
+
+        const goalSchedulers: GoalScheduler[] = toArray(repoContext.configuration.sdm.goalScheduler) || [];
+        const k8sScheduler = goalSchedulers.find(gs => gs instanceof KubernetesGoalScheduler) as KubernetesGoalScheduler;
+        if (!k8sScheduler) {
+            throw new Error("Failed to find KubernetesGoalScheduler in goal schedulers");
+        }
+        if (!k8sScheduler.podSpec) {
+            throw new Error("KubernetesGoalScheduler has no podSpec defined");
+        }
+        const image: string = _.get(k8sScheduler.podSpec, "spec.containers[0].image");
+        const jobEnvs = k8sJobEnv(k8sScheduler.podSpec, goalEvent, repoContext.context as any);
+
+        const serviceSpec: { type: string, spec: K8sServiceSpec } = {
+            type: K8sServiceRegistrationType.K8sService,
+            spec: {
+                container: spec.containers,
+                initContainer: {
+                    env: [
+                        ...jobEnvs,
+                        {
+                            name: "ATOMIST_ISOLATED_GOAL_INIT",
+                            value: "true",
+                        },
+                    ],
+                    image,
+                    name: "atm-init",
+                    volumeMounts: [
+                        {
+                            mountPath: ContainerProjectHome,
+                            name: "home",
+                        },
+                    ],
+                    workingDir: ContainerProjectHome,
+                },
+                volume: [
+                    {
+                        name: "home",
+                        emptyDir: {},
+                    },
+                ],
+                volumeMount: [
+                    {
+                        mountPath: ContainerProjectHome,
+                        name: "home",
+                    },
+                ],
+            },
+        };
+
+        const data: any = JSON.parse(goalEvent.data || "{}");
+        const servicesData: any = {};
+        _.set<any>(servicesData, `${ServiceRegistrationGoalDataKey}.${registration.name}`, serviceSpec);
+        goalEvent.data = JSON.stringify(_.merge(data, servicesData));
+        return goalEvent;
+    };
+}
+
+/** Container information useful the various functions. */
+interface K8sContainer {
+    /** Kubernetes configuration to use when creating API clients */
+    config: k8s.KubeConfig;
+    /** Name of container in pod */
+    name: string;
+    /** Pod name */
+    pod: string;
+    /** Pod namespace */
+    ns: string;
+    /** Log */
+    log: ProgressLog;
+}
+
+/**
+ * Wait for first container to exit and stream its logs to the
+ * progress log.
+ */
+export function executeK8sJob(goal: Container, registration: K8sContainerRegistration): ExecuteGoal {
+    return doWithProject(async gi => {
+        const { context, goalEvent, progressLog, project } = gi;
+
+        if (process.env.ATOMIST_ISOLATED_GOAL_INIT === "true") {
+            try {
+                await copyProject(project.baseDir, process.cwd());
+            } catch (e) {
+                const message = `Failed to copy project for goal execution: ${e.message}`;
+                loglog(message, logger.error, progressLog);
+                return { code: 1, message };
+            }
+            goalEvent.state = SdmGoalState.in_process;
+            return goalEvent;
+        }
+
+        const spec: K8sGoalContainerSpec = _.merge({}, { containers: registration.containers, volumes: registration.volumes },
+            (registration.callback) ? await registration.callback(registration, project, goal, goalEvent, context) : {});
+        let containerName: string = _.get(spec, "containers[0].name");
+        if (!containerName) {
+            const msg = `Failed to get main container name from goal registration: ${stringify(spec)}`;
+            loglog(msg, logger.warn, progressLog);
+            let svcSpec: K8sServiceSpec;
+            try {
+                const data = JSON.parse(goalEvent.data || "{}");
+                svcSpec = _.get(data, `${ServiceRegistrationGoalDataKey}.${registration.name}.spec`);
+            } catch (e) {
+                const message = `Failed to parse Kubernetes spec from goal data '${goalEvent.data}': ${e.message}`;
+                loglog(message, logger.error, progressLog);
+                return { code: 1, message };
+            }
+            containerName = _.get(svcSpec, "container[1].name");
+            if (!containerName) {
+                const message = `Failed to get main container name from either goal registration or data: '${goalEvent.data}'`;
+                loglog(message, logger.error, progressLog);
+                return { code: 1, message };
+            }
+        }
+        const ns = await readNamespace();
+        const podName = os.hostname();
+
+        let kc: k8s.KubeConfig;
+        try {
+            kc = loadKubeConfig();
+        } catch (e) {
+            const message = `Failed to load Kubernetes configuration: ${e.message}`;
+            loglog(message, logger.error, progressLog);
+            return { code: 1, message };
+        }
+
+        const container: K8sContainer = {
+            config: kc,
+            name: containerName,
+            pod: podName,
+            ns,
+            log: progressLog,
+        };
+
+        try {
+            await containerStarted(container);
+        } catch (e) {
+            loglog(e.message, logger.error, progressLog);
+            return { code: 1, message: e.message };
+        }
+
+        const log = followK8sLog(container);
+
+        const status = { code: 0, message: `Container '${containerName}' completed successfully` };
+        try {
+            const podStatus = await containerWatch(container);
+            loglog(`Container '${containerName}' exited: ${stringify(podStatus)}`, logger.debug, progressLog);
+        } catch (e) {
+            const message = `Container '${containerName}' failed: ${e.message}`;
+            loglog(message, logger.error, progressLog);
+            status.code++;
+            status.message = message;
+        } finally {
+            // Give the logs some time to be delivered
+            await sleep(1000);
+            log.abort();
+        }
+
+        try {
+            await copyProject(process.cwd(), project.baseDir);
+        } catch (e) {
+            const message = `Failed to update project after goal execution: ${e.message}`;
+            loglog(message, logger.error, progressLog);
+            status.code++;
+            status.message += ` but f${message.slice(1)}`;
+        }
+        return status;
+    }, { readOnly: false });
+}
+
+/**
+ * Wait for container in pod to start, return when it does.
+ *
+ * @param container Information about container to check
+ * @param attempts Maximum number of attempts, waiting 500 ms between
+ */
+async function containerStarted(container: K8sContainer, attempts: number = 120): Promise<void> {
+    let core: k8s.CoreV1Api;
+    try {
+        core = container.config.makeApiClient(k8s.CoreV1Api);
+    } catch (e) {
+        e.message = `Failed to create Kubernetes core API client: ${e.message}`;
+        loglog(e.message, logger.error, container.log);
+        throw e;
+    }
+
+    const sleepTime = 500; // ms
+    for (let i = 0; i < attempts; i++) {
+        await sleep(500);
+        const pod = (await core.readNamespacedPod(container.pod, container.ns)).body;
+        const containerStatus = pod.status.containerStatuses.find(c => c.name === container.name);
+        if (containerStatus && (!!_.get(containerStatus, "state.running.startedAt") || !!_.get(containerStatus, "state.terminated"))) {
+            const message = `Container '${container.name}' started`;
+            loglog(message, logger.debug, container.log);
+            return;
+        }
+    }
+
+    const errMsg = `Container '${container.name}' failed to start within ${attempts * sleepTime} ms`;
+    loglog(errMsg, logger.error, container.log);
+    throw new Error(errMsg);
+}
+
+/**
+ * Watch pod until container `container.name` exits.  Resolve promise
+ * with status if container `container.name` exits with status 0.
+ * Reject promise otherwise, including pod status in the `podStatus`
+ * property of the error.
+ *
+ * @param container Information about container to watch
+ * @return Status of pod after container terminates
+ */
+function containerWatch(container: K8sContainer): Promise<k8s.V1PodStatus> {
+    return new Promise((resolve, reject) => {
+        let watch: k8s.Watch;
+        try {
+            watch = new k8s.Watch(container.config);
+        } catch (e) {
+            e.message = `Failed to create Kubernetes watch client: ${e.message}`;
+            loglog(e.message, logger.error, container.log);
+            reject(e);
+        }
+        const watchPath = `/api/v1/watch/namespaces/${container.ns}/pods/${container.pod}`;
+        let watcher: any;
+        watcher = watch.watch(watchPath, {}, (phase, obj) => {
+            const pod = obj as k8s.V1Pod;
+            if (pod && pod.status && pod.status.containerStatuses) {
+                const containerStatus = pod.status.containerStatuses.find(c => c.name === container.name);
+                if (containerStatus && containerStatus.state && containerStatus.state.terminated) {
+                    const exitCode: number = _.get(containerStatus, "state.terminated.exitCode");
+                    if (exitCode === 0) {
+                        const msg = `Container '${container.name}' exited with status 0`;
+                        loglog(msg, logger.info, container.log);
+                        resolve(pod.status);
+                    } else {
+                        const msg = `Container '${container.name}' exited with status ${exitCode}`;
+                        loglog(msg, logger.error, container.log);
+                        const err = new Error(msg);
+                        (err as any).podStatus = pod.status;
+                        reject(err);
+                    }
+                    if (watcher) {
+                        watcher.abort();
+                    }
+                    return;
+                }
+            }
+            loglog(`Container '${container.name}' still running`, logger.debug, container.log);
+        }, err => {
+            err.message = `Container watcher failed: ${err.message}`;
+            loglog(err.message, logger.error, container.log);
+            reject(err);
+        });
+    });
+}
+
+/**
+ * Set up log follower for container.
+ */
+function followK8sLog(container: K8sContainer): request.Request {
+    const k8sLog = new k8s.Log(container.config);
+    const logStream = new Writable({
+        write: (chunk, encoding, callback) => {
+            container.log.write(chunk.toString());
+            callback();
+        },
+    });
+    const doneCallback = e => {
+        if (e) {
+            if (e.message) {
+                loglog(e.message, logger.error, container.log);
+            } else {
+                loglog(stringify(e), logger.error, container.log);
+            }
+        }
+    };
+    const logOptions: k8s.LogOptions = { follow: true };
+    return k8sLog.log(container.ns, container.pod, container.name, logStream, doneCallback, logOptions);
+}

--- a/lib/goal/container/util.ts
+++ b/lib/goal/container/util.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LeveledLogMethod } from "@atomist/automation-client";
+import {
+    ProgressLog,
+    SdmContext,
+    SdmGoalEvent,
+} from "@atomist/sdm";
+import * as fs from "fs-extra";
+import { readSdmVersion } from "../../internal/delivery/build/local/projectVersioner";
+import { K8sNamespaceFile } from "../../pack/k8s/KubernetesGoalScheduler";
+
+/**
+ * Simple test to see if SDM is running in Kubernetes.  It is called
+ * from a non-async function, so it must be non-async.
+ *
+ * @return `true` if process is running in Kubernetes, `false` otherwise.
+ */
+export function runningInK8s(): boolean {
+    return fs.pathExistsSync(K8sNamespaceFile);
+}
+
+/**
+ * Return environment variables required by the container goal
+ * execution machinery.
+ *
+ * @param goalEvent SDM goal event being executed as a container goal
+ * @param ctx SDM context for goal execution
+ * @return SDM goal environment variables
+ */
+export async function containerEnvVars(goalEvent: SdmGoalEvent, ctx: SdmContext): Promise<Array<{ name: string, value: string }>> {
+    const version = await readSdmVersion(
+        goalEvent.repo.owner,
+        goalEvent.repo.name,
+        goalEvent.repo.providerId,
+        goalEvent.sha,
+        goalEvent.branch,
+        ctx.context,
+    );
+    return [{
+        name: "ATOMIST_SLUG",
+        value: `${goalEvent.repo.owner}/${goalEvent.repo.name}`,
+    }, {
+        name: "ATOMIST_OWNER",
+        value: goalEvent.repo.owner,
+    }, {
+        name: "ATOMIST_REPO",
+        value: goalEvent.repo.name,
+    }, {
+        name: "ATOMIST_SHA",
+        value: goalEvent.sha,
+    }, {
+        name: "ATOMIST_BRANCH",
+        value: goalEvent.branch,
+    }, {
+        name: "ATOMIST_VERSION",
+        value: version,
+    }, {
+        name: "ATOMIST_GOAL_SET_ID",
+        value: goalEvent.goalSetId,
+    }, {
+        name: "ATOMIST_GOAL",
+        value: goalEvent.uniqueName,
+    }].filter(e => !!e.value);
+}
+
+/**
+ * Copy cloned project to location that can be mounted into container.
+ * It ensures the destination direction exists and is empty.  If it
+ * fails it throws an error and tries to ensure the destination
+ * directory does not exist.
+ *
+ * @param src Location of project directory
+ * @param dest Location to copy project to
+ */
+export async function copyProject(src: string, dest: string): Promise<void> {
+    try {
+        await fs.emptyDir(dest);
+    } catch (e) {
+        e.message = `Failed to empty directory '${dest}'`;
+        throw e;
+    }
+    try {
+        await fs.copy(src, dest);
+    } catch (e) {
+        e.message = `Failed to copy project from '${src}' to '${dest}'`;
+        try {
+            await fs.remove(dest);
+        } catch (err) {
+            e.message += `; Failed to clean up '${dest}': ${err.message}`;
+        }
+        throw e;
+    }
+}
+
+/**
+ * Write to client and progress logs.  Add newline to progress log.
+ *
+ * @param msg Message to write, should not have newline at end
+ * @param l Logger method, e.g., `logger.warn`
+ * @param p Progress log
+ */
+export function loglog(msg: string, l: LeveledLogMethod, p: ProgressLog): void {
+    l(msg);
+    p.write(msg + "\n");
+}

--- a/lib/pack/k8s/KubernetesGoalScheduler.ts
+++ b/lib/pack/k8s/KubernetesGoalScheduler.ts
@@ -22,12 +22,14 @@ import {
     Configuration,
     configurationValue,
     doWithRetry,
+    HandlerContext,
     logger,
 } from "@atomist/automation-client";
 import {
     ExecuteGoalResult,
     GoalInvocation,
     GoalScheduler,
+    SdmGoalEvent,
     ServiceRegistrationGoalDataKey,
 } from "@atomist/sdm";
 import * as k8s from "@kubernetes/client-node";
@@ -36,6 +38,7 @@ import * as fs from "fs-extra";
 import * as stringify from "json-stringify-safe";
 import * as _ from "lodash";
 import * as os from "os";
+import { DeepPartial } from "ts-essentials";
 import { toArray } from "../../util/misc/array";
 import {
     loadKubeClusterConfig,
@@ -63,7 +66,7 @@ export interface KubernetesGoalSchedulerOptions {
  */
 export class KubernetesGoalScheduler implements GoalScheduler {
 
-    private podSpec: k8s.V1Pod;
+    public podSpec: k8s.V1Pod;
 
     constructor(private readonly options: KubernetesGoalSchedulerOptions = { isolateAll: false }) {
     }
@@ -88,7 +91,7 @@ export class KubernetesGoalScheduler implements GoalScheduler {
         const podNs = await readNamespace();
 
         const kc = loadKubeConfig();
-        const batch = kc.makeApiClient(k8s.Batch_v1Api);
+        const batch = kc.makeApiClient(k8s.BatchV1Api);
 
         const jobSpec = createJobSpec(_.cloneDeep(this.podSpec), podNs, gi);
         const jobDesc = `k8s job '${jobSpec.metadata.namespace}:${jobSpec.metadata.name}' for goal '${goalEvent.uniqueName}'`;
@@ -168,7 +171,7 @@ export class KubernetesGoalScheduler implements GoalScheduler {
 
         try {
             const kc = loadKubeClusterConfig();
-            const core = kc.makeApiClient(k8s.Core_v1Api);
+            const core = kc.makeApiClient(k8s.CoreV1Api);
 
             this.podSpec = (await core.readNamespacedPod(podName, podNs)).body;
         } catch (e) {
@@ -215,7 +218,7 @@ export async function cleanCompletedJobs(): Promise<void> {
             completedJobs.map(j => `${j.metadata.namespace}:${j.metadata.name}`).join(", ")}`);
 
         const kc = loadKubeConfig();
-        const batch = kc.makeApiClient(k8s.Batch_v1Api);
+        const batch = kc.makeApiClient(k8s.BatchV1Api);
         for (const completedSdmJob of completedJobs) {
             try {
                 await batch.deleteNamespacedJob(
@@ -231,62 +234,85 @@ export async function cleanCompletedJobs(): Promise<void> {
     }
 }
 
+/** Unique name for goal to use in k8s job spec. */
+function k8sJobGoalName(goalEvent: SdmGoalEvent): string {
+    return goalEvent.uniqueName.split("#")[0].toLowerCase();
+}
+
+/** Unique name for job to use in k8s job spec. */
+export function k8sJobName(podSpec: k8s.V1Pod, goalEvent: SdmGoalEvent): string {
+    const goalName = k8sJobGoalName(goalEvent);
+    return `${podSpec.spec.containers[0].name}-job-${goalEvent.goalSetId.slice(0, 7)}-${goalName}`
+        .slice(0, 63).replace(/[^a-z0-9]*$/, "");
+}
+
+/**
+ * Kubernetes container spec environment variables that specify an SDM
+ * running in single-goal mode.
+ */
+export function k8sJobEnv(podSpec: k8s.V1Pod, goalEvent: SdmGoalEvent, context: HandlerContext): k8s.V1EnvVar[] {
+    const goalName = k8sJobGoalName(goalEvent);
+    const jobName = k8sJobName(podSpec, goalEvent);
+    const envVars: Array<DeepPartial<k8s.V1EnvVar>> = [
+        {
+            name: "ATOMIST_JOB_NAME",
+            value: jobName,
+        },
+        {
+            name: "ATOMIST_REGISTRATION_NAME",
+            value: `${automationClientInstance().configuration.name}-job-${goalEvent.goalSetId.slice(0, 7)}-${goalName}`,
+        },
+        {
+            name: "ATOMIST_GOAL_TEAM",
+            value: context.workspaceId,
+        },
+        {
+            name: "ATOMIST_GOAL_TEAM_NAME",
+            value: (context as any as AutomationContextAware).context.workspaceName,
+        },
+        {
+            name: "ATOMIST_GOAL_ID",
+            value: (goalEvent as any).id,
+        },
+        {
+            name: "ATOMIST_GOAL_SET_ID",
+            value: goalEvent.goalSetId,
+        },
+        {
+            name: "ATOMIST_GOAL_UNIQUE_NAME",
+            value: goalEvent.uniqueName,
+        },
+        {
+            name: "ATOMIST_CORRELATION_ID",
+            value: context.correlationId,
+        },
+        {
+            name: "ATOMIST_ISOLATED_GOAL",
+            value: "true",
+        },
+    ];
+    return envVars as k8s.V1EnvVar[];
+}
+
 /**
  * Create a jobSpec by modifying the provided podSpec
  * @param podSpec
  * @param podNs
  * @param gi
- * @param context
  */
 export function createJobSpec(podSpec: k8s.V1Pod, podNs: string, gi: GoalInvocation): k8s.V1Job {
     const { goalEvent, context } = gi;
-    const goalName = goalEvent.uniqueName.split("#")[0].toLowerCase();
 
     const jobSpec = createJobSpecWithAffinity(podSpec, gi);
 
-    jobSpec.metadata.name = (`${podSpec.spec.containers[0].name}-job-${goalEvent.goalSetId.slice(0, 7)}-${goalName}`).slice(0, 63);
+    jobSpec.metadata.name = k8sJobName(podSpec, goalEvent);
     jobSpec.metadata.namespace = podNs;
 
     jobSpec.spec.backoffLimit = 1;
     jobSpec.spec.template.spec.restartPolicy = "Never";
     jobSpec.spec.template.spec.containers[0].name = jobSpec.metadata.name;
 
-    jobSpec.spec.template.spec.containers[0].env.push({
-        name: "ATOMIST_JOB_NAME",
-        value: jobSpec.metadata.name,
-    } as any,
-        {
-            name: "ATOMIST_REGISTRATION_NAME",
-            value: `${automationClientInstance().configuration.name}-job-${goalEvent.goalSetId.slice(0, 7)}-${goalName}`,
-        } as any,
-        {
-            name: "ATOMIST_GOAL_TEAM",
-            value: context.workspaceId,
-        } as any,
-        {
-            name: "ATOMIST_GOAL_TEAM_NAME",
-            value: (context as any as AutomationContextAware).context.workspaceName,
-        } as any,
-        {
-            name: "ATOMIST_GOAL_ID",
-            value: (goalEvent as any).id,
-        } as any,
-        {
-            name: "ATOMIST_GOAL_SET_ID",
-            value: goalEvent.goalSetId,
-        } as any,
-        {
-            name: "ATOMIST_GOAL_UNIQUE_NAME",
-            value: goalEvent.uniqueName,
-        } as any,
-        {
-            name: "ATOMIST_CORRELATION_ID",
-            value: context.correlationId,
-        } as any,
-        {
-            name: "ATOMIST_ISOLATED_GOAL",
-            value: "true",
-        } as any);
+    jobSpec.spec.template.spec.containers[0].env.push(...k8sJobEnv(podSpec, goalEvent, context));
 
     rewriteCachePath(jobSpec, context.workspaceId);
 
@@ -496,7 +522,7 @@ export function sanitizeName(name: string): string {
  */
 export async function listJobs(labelSelector?: string): Promise<k8s.V1Job[]> {
     const kc = loadKubeConfig();
-    const batch = kc.makeApiClient(k8s.Batch_v1Api);
+    const batch = kc.makeApiClient(k8s.BatchV1Api);
 
     if (configurationValue<boolean>("sdm.k8s.job.singleNamespace", true)) {
         const podNs = await readNamespace();
@@ -518,7 +544,7 @@ export async function listJobs(labelSelector?: string): Promise<k8s.V1Job[]> {
     }
 }
 
-const NamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+export const K8sNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
 
 /**
  * Read the namespace of the deployment from environment and k8s service account files.
@@ -530,8 +556,8 @@ export async function readNamespace(): Promise<string> {
         return podNs;
     }
 
-    if (await fs.pathExists(NamespaceFile)) {
-        podNs = (await fs.readFile(NamespaceFile)).toString().trim();
+    if (await fs.pathExists(K8sNamespaceFile)) {
+        podNs = (await fs.readFile(K8sNamespaceFile)).toString().trim();
     }
 
     if (!!podNs) {

--- a/lib/pack/k8s/KubernetesJobDeletingGoalCompletionListener.ts
+++ b/lib/pack/k8s/KubernetesJobDeletingGoalCompletionListener.ts
@@ -65,7 +65,7 @@ export class KubernetesJobDeletingGoalCompletionListenerFactory {
 
             logger.debug(
                 `Found k8s jobs for goal set '${goalEvent.goalSetId}': '${
-                    jobs.map(j => `${j.metadata.namespace}:${j.metadata.name}`).join(", ")}'`);
+                jobs.map(j => `${j.metadata.namespace}:${j.metadata.name}`).join(", ")}'`);
 
             const goalJobs = jobs.filter(j => {
                 const annotations = j.metadata.annotations;
@@ -78,7 +78,7 @@ export class KubernetesJobDeletingGoalCompletionListenerFactory {
 
             logger.debug(
                 `Matching k8s job for goal '${goalEvent.uniqueName}' found: '${
-                    goalJobs.map(j => `${j.metadata.namespace}:${j.metadata.name}`).join(", ")}'`);
+                goalJobs.map(j => `${j.metadata.namespace}:${j.metadata.name}`).join(", ")}'`);
 
             const ttl: number = _.get(this.sdm.configuration, "sdm.k8s.job.ttl", 1000 * 60 * 2);
 
@@ -96,29 +96,29 @@ export class KubernetesJobDeletingGoalCompletionListenerFactory {
 
     private initialize(): void {
         setInterval(async () => {
-                const now = Date.now();
-                for (const uid of this.cache.keys()) {
-                    const job = this.cache.get(uid);
-                    if (job.ttl <= now) {
-                        logger.debug(`Deleting k8s job '${job.namespace}:${job.name}'`);
+            const now = Date.now();
+            for (const uid of this.cache.keys()) {
+                const job = this.cache.get(uid);
+                if (job.ttl <= now) {
+                    logger.debug(`Deleting k8s job '${job.namespace}:${job.name}'`);
 
-                        // First delete the job
-                        await this.deleteJob(job);
+                    // First delete the job
+                    await this.deleteJob(job);
 
-                        logger.debug(`Deleting k8s pods for job '${job.namespace}:${job.name}'`);
-                        // Next, delete all still existing jobs
-                        await this.deletePods(job);
-                        this.cache.delete(uid);
-                    }
+                    logger.debug(`Deleting k8s pods for job '${job.namespace}:${job.name}'`);
+                    // Next, delete all still existing jobs
+                    await this.deletePods(job);
+                    this.cache.delete(uid);
                 }
-            },
+            }
+        },
             _.get(this.sdm.configuration, "sdm.k8s.job.ttlCheckInterval", 15000));
     }
 
     private async deleteJob(job: { name: string, namespace: string }): Promise<void> {
         try {
             const kc = loadKubeConfig();
-            const batch = kc.makeApiClient(k8s.Batch_v1Api);
+            const batch = kc.makeApiClient(k8s.BatchV1Api);
 
             await batch.readNamespacedJob(job.name, job.namespace);
             try {
@@ -138,7 +138,7 @@ export class KubernetesJobDeletingGoalCompletionListenerFactory {
     private async deletePods(job: { name: string, namespace: string }): Promise<void> {
         try {
             const kc = loadKubeConfig();
-            const core = kc.makeApiClient(k8s.Core_v1Api);
+            const core = kc.makeApiClient(k8s.CoreV1Api);
 
             const selector = `job-name=${job.name}`;
             const pods = await core.listNamespacedPod(
@@ -156,7 +156,7 @@ export class KubernetesJobDeletingGoalCompletionListenerFactory {
                         // Probably ok because pod might be gone already
                         logger.debug(
                             `Failed to delete k8s pod '${pod.metadata.namespace}:${pod.metadata.name}': ${
-                                prettyPrintError(e)}`);
+                            prettyPrintError(e)}`);
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,19 +478,19 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.8.2.tgz",
-      "integrity": "sha512-crS3h59+fOGXQgxVdq3XH81ytY7FV2HnB5z/+lSWD3bi5D5lHKu3PVN2PHCDMNExPy0KthcfqBoIVFVy4CoG3A==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.10.2.tgz",
+      "integrity": "sha512-JvsmxbTwiMqsh9LyuXMzT5HjoENFbB3a/JroJsobuAzkxN162UqAOvg++/AA+ccIMWRR2Qln4FyaOJ0a4eKyXg==",
       "requires": {
-        "@types/js-yaml": "^3.11.2",
+        "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
         "@types/request": "^2.47.1",
         "@types/underscore": "^1.8.9",
         "@types/ws": "^6.0.1",
-        "byline": "^5.0.0",
         "isomorphic-ws": "^4.0.1",
-        "js-yaml": "^3.12.0",
-        "jsonpath": "^1.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stream": "^1.0.0",
+        "jsonpath-plus": "^0.19.0",
         "request": "^2.88.0",
         "shelljs": "^0.8.2",
         "tslib": "^1.9.3",
@@ -499,9 +499,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
-          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
+          "version": "10.14.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
         }
       }
     },
@@ -1042,7 +1042,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -1139,8 +1138,7 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -1438,9 +1436,9 @@
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@types/underscore": {
-      "version": "1.8.18",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.18.tgz",
-      "integrity": "sha512-mXQ8u416FWMPjp2zWrcVmOZtzKQM6IeyVcuE+RGF/04JLBrMjfnmNKn74VN8fIkFzU97TpzkP0ny0p0h65eC7w=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.9.0.tgz",
+      "integrity": "sha512-1koEJ2AhXaR0HVP3VlN0pCb51n87g5QL9rUiGaY+Nte9gBd2FYf/zNvS5ZtHg7o6owYNS6QA/4ZJ/mIiz2q1hA=="
     },
     "@types/utf8": {
       "version": "2.1.6",
@@ -2432,7 +2430,8 @@
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+      "dev": true
     },
     "bytes": {
       "version": "3.1.0",
@@ -3238,7 +3237,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "deepmerge": {
       "version": "3.2.0",
@@ -3694,6 +3694,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -3705,7 +3706,8 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
         }
       }
     },
@@ -3831,12 +3833,14 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -4170,7 +4174,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fast-safe-stringify": {
       "version": "2.0.6",
@@ -6409,6 +6414,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-stream/-/json-stream-1.0.0.tgz",
+      "integrity": "sha1-GjhU4o0rvuqzHMfd9oPS3cVlJwg="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -6438,27 +6448,10 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonpath": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
-      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.7.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-        },
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-        }
-      }
+    "jsonpath-plus": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6514,6 +6507,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -7676,6 +7670,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -8205,7 +8200,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -9016,7 +9012,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -9123,14 +9120,6 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
-    },
-    "static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "requires": {
-        "escodegen": "^1.8.1"
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -9683,6 +9672,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -10203,7 +10193,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "url": "https://github.com/atomist/sdm-core/issues"
   },
   "dependencies": {
-    "@kubernetes/client-node": "^0.8.2",
+    "@kubernetes/client-node": "^0.10.2",
     "@octokit/rest": "^16.3.0",
+    "@types/glob": "^7.1.1",
     "@types/proper-lockfile": "^3.0.0",
     "@types/request": "^2.48.1",
     "@types/retry": "^0.10.2",
@@ -40,6 +41,7 @@
     "moment-duration-format": "2.2.2",
     "promise-retry": "^1.1.1",
     "proper-lockfile": "^3.2.0",
+    "request": "^2.88.0",
     "retry": "^0.12.0",
     "tmp-promise": "^1.0.4",
     "ts-essentials": "^1.0.2"
@@ -98,8 +100,8 @@
     "lint:gql:fix": "prettier --write \"lib/graphql/**/*.graphql\"",
     "lint:ts": "tslint --format verbose --project . --exclude \"{build,node_modules}/**\" \"**/*.ts\"",
     "lint:ts:fix": "npm run lint:ts -- --fix",
-    "test": "mocha --require ts-node/register --require source-map-support/register \"test/**/*est.ts\"",
-    "test:one": "mocha --require espower-typescript/guess \"test/**/${TEST:-*.ts}\"",
+    "test": "mocha --require espower-typescript/guess \"test/**/*.test.ts\"",
+    "test:one": "mocha --require espower-typescript/guess \"test/**/${TEST:-*.test.ts}\"",
     "typedoc": "npm run doc"
   },
   "engines": {

--- a/test/goal/cache/CompressingGoalCache.test.ts
+++ b/test/goal/cache/CompressingGoalCache.test.ts
@@ -53,13 +53,13 @@ describe("CompressingGoalCache", () => {
 
     async function createTempProject(fakePushId: RepoRef): Promise<LocalProject> {
         const projectDir = testDir();
-        fs.mkdirSync(projectDir);
+        await fs.ensureDir(projectDir);
         return NodeFsLocalProject.fromExistingDirectory(fakePushId, projectDir);
     }
 
     const ErrorProjectListenerRegistration: GoalProjectListenerRegistration = {
         name: "Error",
-        listener: async () => { throw Error(""); },
+        listener: async () => { throw Error("Cache miss"); },
         pushTest: AnyPush,
     };
 

--- a/test/goal/container/docker.test.ts
+++ b/test/goal/container/docker.test.ts
@@ -1,0 +1,592 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitProject,
+    guid,
+    NodeFsLocalProject,
+} from "@atomist/automation-client";
+import {
+    execPromise,
+    ExecuteGoalResult,
+    fakePush,
+    GoalInvocation,
+} from "@atomist/sdm";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import * as assert from "power-assert";
+import {
+    Container,
+    GoalContainer,
+} from "../../../lib/goal/container/container";
+import {
+    containerDockerOptions,
+    executeDockerJob,
+} from "../../../lib/goal/container/docker";
+import { runningInK8s } from "../../../lib/goal/container/util";
+import { containerTestImage } from "./util";
+
+/* tslint:disable:max-file-line-count */
+
+describe("goal/container/docker", () => {
+
+    describe("containerDockerOptions", () => {
+
+        it("should return an empty array", () => {
+            const c = {
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+            };
+            const r = {
+                containers: [c],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = [];
+            assert.deepStrictEqual(o, e);
+        });
+
+        it("should handle command as entrypoint", () => {
+            const c = {
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+                command: ["daughter"],
+            };
+            const r = {
+                containers: [c],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = ["--entrypoint=daughter"];
+            assert.deepStrictEqual(o, e);
+        });
+
+        it("should move extra command elements to args", () => {
+            const c: GoalContainer = {
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+                command: ["daughter", "of", "a", "miner"],
+            };
+            const r = {
+                containers: [c],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = ["--entrypoint=daughter"];
+            assert.deepStrictEqual(o, e);
+            assert.deepStrictEqual(c.args, ["of", "a", "miner"]);
+        });
+
+        it("should prepend extra command elements to args", () => {
+            const c = {
+                args: ["her", "ways", "were", "free"],
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+                command: ["daughter", "of", "a", "miner"],
+            };
+            const r = {
+                containers: [c],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = ["--entrypoint=daughter"];
+            assert.deepStrictEqual(o, e);
+            assert.deepStrictEqual(c.args, ["of", "a", "miner", "her", "ways", "were", "free"]);
+        });
+
+        it("should handle env", () => {
+            const c = {
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+                env: [
+                    {
+                        name: "DAUGHTER",
+                        value: "miner",
+                    },
+                    {
+                        name: "DAYS",
+                        value: "free",
+                    },
+                    {
+                        name: "SUNSHINE",
+                        value: "walked beside her",
+                    },
+                ],
+            };
+            const r = {
+                containers: [c],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = ["--env=DAUGHTER=miner", "--env=DAYS=free", "--env=SUNSHINE=walked beside her"];
+            assert.deepStrictEqual(o, e);
+        });
+
+        it("should handle ports", () => {
+            const c = {
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+                ports: [
+                    {
+                        containerPort: 1238,
+                    },
+                    {
+                        containerPort: 2247,
+                    },
+                    {
+                        containerPort: 4304,
+                    },
+                ],
+            };
+            const r = {
+                containers: [c],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = ["-p=1238", "-p=2247", "-p=4304"];
+            assert.deepStrictEqual(o, e);
+        });
+
+        it("should handle volumes", () => {
+            const c = {
+                image: "townes/tecumseh-valley:4.55",
+                name: "townes",
+                volumeMounts: [
+                    {
+                        mountPath: "/like/a/summer/thursday",
+                        name: "Thursday",
+                    },
+                    {
+                        mountPath: "/our/mother/the/mountain",
+                        name: "mountain",
+                    },
+                ],
+            };
+            const r = {
+                containers: [c],
+                volumes: [
+                    {
+                        hostPath: {
+                            path: "/home/mountain",
+                        },
+                        name: "mountain",
+                    },
+                    {
+                        hostPath: {
+                            path: "/mnt/thursday",
+                        },
+                        name: "Thursday",
+                    },
+                ],
+            };
+            const o = containerDockerOptions(c, r);
+            const e = ["--volume=/mnt/thursday:/like/a/summer/thursday", "--volume=/home/mountain:/our/mother/the/mountain"];
+            assert.deepStrictEqual(o, e);
+        });
+
+    });
+
+    describe("executeDockerJob", () => {
+
+        const fakeId = fakePush().id;
+        const goal = new Container();
+        const projectDir = path.join(os.tmpdir(), "atomist-sdm-core-docker-test-" + guid());
+        let project: GitProject;
+        const tmpDirs: string[] = [];
+        let logData = "";
+        const goalInvocation: GoalInvocation = {
+            context: {
+                graphClient: {
+                    query: () => ({ SdmVersion: [{ version: "3.1.3-20200220200220" }] }),
+                },
+            },
+            configuration: {
+                sdm: {
+                    projectLoader: {
+                        doWithProject: (o, a) => a(project),
+                    },
+                },
+            },
+            credentials: {},
+            goalEvent: {
+                branch: fakeId.branch,
+                goalSetId: "27c20de4-2c88-480a-b4e7-f6c6d5a1d623",
+                repo: {
+                    name: fakeId.repo,
+                    owner: fakeId.owner,
+                    providerId: "album",
+                },
+                sha: fakeId.sha,
+                uniqueName: goal.definition.uniqueName,
+            },
+            id: fakeId,
+            progressLog: {
+                write: d => { logData += d; },
+            },
+        } as any;
+
+        before(async function dockerCheckProjectSetup(): Promise<void> {
+            // tslint:disable-next-line:no-invalid-this
+            this.timeout(20000);
+            if (runningInK8s() || (!process.env.DOCKER_HOST && !fs.existsSync("/var/run/docker.sock"))) {
+                // tslint:disable-next-line:no-invalid-this
+                this.skip();
+                return;
+            }
+            try {
+                await execPromise("docker", ["pull", "alpine:3.9.4"]);
+            } catch (e) {
+                // tslint:disable-next-line:no-invalid-this
+                this.skip();
+                return;
+            }
+            await fs.ensureDir(projectDir);
+            tmpDirs.push(projectDir);
+            project = await NodeFsLocalProject.fromExistingDirectory(fakeId, projectDir) as any;
+        });
+
+        beforeEach(() => { logData = ""; });
+
+        after(async function directoryCleanup(): Promise<void> {
+            await Promise.all(tmpDirs.map(d => fs.remove(d)));
+        });
+
+        it("should run a docker container", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+        }).timeout(10000);
+
+        it("should throw an error if there are no containers", async () => {
+            const r = {
+                containers: [],
+            };
+            const e = executeDockerJob(goal, r);
+            try {
+                await e(goalInvocation);
+                assert.fail("execution of goal without containers should have thrown an error");
+            } catch (e) {
+                assert(/No containers defined in GoalContainerSpec/.test(e.message));
+            }
+        });
+
+        it("should report when the container fails", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["false"],
+                        image: containerTestImage,
+                        name: "alpine",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 1);
+            assert(x.message.startsWith("Docker container 'sdm-alpine-27c20de-container' failed"));
+        }).timeout(10000);
+
+        it("should run multiple containers", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                    },
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine1",
+                    },
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine2",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+        }).timeout(10000);
+
+        it("should report when main container fails", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["false"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                    },
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine1",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 1, logData);
+            assert(x.message.startsWith("Docker container 'sdm-alpine0-27c20de-container' failed"));
+        }).timeout(10000);
+
+        it("should ignore when sidecar container fails", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                    },
+                    {
+                        args: ["false"],
+                        image: containerTestImage,
+                        name: "alpine1",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+        }).timeout(10000);
+
+        it("should only wait on main container", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                    },
+                    {
+                        args: ["sleep", "20"],
+                        image: containerTestImage,
+                        name: "alpine1",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+        }).timeout(10000);
+
+        it("should allow containers to communicate", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["sleep 1; ping -w 1 alpine1"],
+                        command: ["sh", "-c"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                    },
+                    {
+                        args: ["sleep", "20"],
+                        image: containerTestImage,
+                        name: "alpine1",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+        }).timeout(15000);
+
+        it("should use the registration callback", async () => {
+            const r = {
+                callback: async () => {
+                    return {
+                        containers: [
+                            {
+                                args: ["true"],
+                                image: containerTestImage,
+                                name: "alpine",
+                            },
+                        ],
+                    };
+                },
+                containers: [
+                    {
+                        args: ["false"],
+                        image: containerTestImage,
+                        name: "alpine",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+        }).timeout(10000);
+
+        it("should persist changes to project", async () => {
+            const tmpDir = path.join(os.tmpdir(), "atomist-sdm-core-docker-test-" + guid());
+            await fs.ensureDir(tmpDir);
+            tmpDirs.push(tmpDir);
+            const existingFile = `README.${guid()}`;
+            const existingFilePath = path.join(tmpDir, existingFile);
+            await fs.writeFile(existingFilePath, "# After Hours\n");
+            const changeFile = `pigeonCamera.${guid()}`;
+            const changeFilePath = path.join(tmpDir, changeFile);
+            await fs.writeFile(changeFilePath, "Where's my pigeon camera?\n");
+            const deleteFile = `ifyouclosethedoor_${guid()}`;
+            const deleteFilePath = path.join(tmpDir, deleteFile);
+            await fs.writeFile(deleteFilePath, "you won't see me\nyou won't see me\n");
+            const lid = fakePush().id;
+            const lp: GitProject = await NodeFsLocalProject.fromExistingDirectory(lid, tmpDir) as any;
+            const lgi: GoalInvocation = {
+                context: {
+                    graphClient: {
+                        query: () => ({ SdmVersion: [{ version: "3.1.3-20200220200220" }] }),
+                    },
+                },
+                configuration: {
+                    sdm: {
+                        projectLoader: {
+                            doWithProject: (o, a) => a(lp),
+                        },
+                    },
+                },
+                credentials: {},
+                goalEvent: {
+                    branch: lid.branch,
+                    goalSetId: "27c20de4-2c88-480a-b4e7-f6c6d5a1d623",
+                    repo: {
+                        name: lid.repo,
+                        owner: lid.owner,
+                        providerId: "album",
+                    },
+                    sha: lid.sha,
+                    uniqueName: goal.definition.uniqueName,
+                },
+                id: lid,
+                progressLog: {
+                    write: () => { },
+                },
+            } as any;
+            const newFile = `project-test-0-${guid()}`;
+            const newFilePath = path.join(tmpDir, newFile);
+            const r = {
+                containers: [
+                    {
+                        args: [
+                            `echo 'This is only a local test' > ${newFile}` +
+                            `; echo 'By now it could be anywhere.' >> ${changeFile}` +
+                            `; rm ${deleteFile}`,
+                        ],
+                        command: ["sh", "-c"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                    },
+                ],
+            };
+            const edj = executeDockerJob(goal, r);
+            const egr = await edj(lgi);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+            const t = await lp.getFile(newFile);
+            assert(t, "file created in container does not exist");
+            const tc = await t.getContent();
+            assert(tc === "This is only a local test\n");
+            const tcf = await fs.readFile(newFilePath, "utf8");
+            assert(tcf === "This is only a local test\n");
+            const e = await lp.getFile(existingFile);
+            assert(e, "file existing in project disappeared");
+            const ec = await e.getContent();
+            assert(ec === "# After Hours\n");
+            const ecf = await fs.readFile(existingFilePath, "utf8");
+            assert(ecf === "# After Hours\n");
+            const c = await lp.getFile(changeFile);
+            assert(c, "file changed in project disappeared");
+            const cc = await c.getContent();
+            assert(cc === "Where's my pigeon camera?\nBy now it could be anywhere.\n");
+            const ccf = await fs.readFile(changeFilePath, "utf8");
+            assert(ccf === "Where's my pigeon camera?\nBy now it could be anywhere.\n");
+            assert(!await lp.getFile(deleteFile), "deleted file still exists in project");
+            assert(!fs.existsSync(deleteFilePath), "deleted file still exists on file system");
+        }).timeout(10000);
+
+        it("should use volumes", async () => {
+            const tmpDir = path.join(os.homedir(), ".atomist", "tmp", guid());
+            await fs.ensureDir(tmpDir);
+            tmpDirs.push(tmpDir);
+            const tmpFile = `volume-test-0-${guid()}`;
+            const r = {
+                containers: [
+                    {
+                        args: [`echo 'This is only a test' > /test/vol0/${tmpFile}`],
+                        command: ["sh", "-c"],
+                        image: containerTestImage,
+                        name: "alpine0",
+                        volumeMounts: [
+                            {
+                                mountPath: "/test/vol0",
+                                name: "test-volume",
+                            },
+                        ],
+                    },
+                ],
+                volumes: [
+                    {
+                        hostPath: {
+                            path: tmpDir,
+                        },
+                        name: "test-volume",
+                    },
+                ],
+            };
+            const e = executeDockerJob(goal, r);
+            const egr = await e(goalInvocation);
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as ExecuteGoalResult;
+            assert(x.code === 0, logData);
+            assert(x.message === "Successfully completed container job");
+            const tmpFilePath = path.join(tmpDir, tmpFile);
+            const tmpContent = await fs.readFile(tmpFilePath, "utf8");
+            assert(tmpContent === "This is only a test\n");
+        }).timeout(10000);
+
+    });
+
+});

--- a/test/goal/container/k8s.test.ts
+++ b/test/goal/container/k8s.test.ts
@@ -272,6 +272,153 @@ describe("goal/container/k8s", () => {
             }
         });
 
+        it("should not set the working directory in the main container", async () => {
+            const r: K8sContainerRegistration = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: "colin/blunstone:1945.6.24",
+                        name: "colin-blunstone",
+                        workingDir: "",
+                    },
+                ],
+                name: "MaybeAfterHesGone",
+            };
+            const c = k8sFulfillmentCallback(g, r);
+            const ge = await c(sge, rc);
+            const p = JSON.parse(ge.data);
+            const d = {
+                "@atomist/sdm/service": {
+                    MaybeAfterHesGone: {
+                        type: "@atomist/sdm/service/k8s",
+                        spec: {
+                            initContainer: {
+                                name: "atm-init",
+                                image: "rod/argent:1945.6.14",
+                                workingDir: "/atm/home",
+                                volumeMounts: [
+                                    {
+                                        mountPath: "/atm/home",
+                                        name: "home",
+                                    },
+                                ],
+                                env: [
+                                    {
+                                        name: "ATOMIST_JOB_NAME",
+                                        value: "rod-argent-job-0abcdef-beechwoodpark.ts",
+                                    },
+                                    {
+                                        name: "ATOMIST_REGISTRATION_NAME",
+                                        value: `@zombies/care-of-cell-44-job-0abcdef-beechwoodpark.ts`,
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_TEAM",
+                                        value: "AR05343M1LY",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_TEAM_NAME",
+                                        value: "Odessey and Oracle",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_ID",
+                                        value: "CHANGES",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_SET_ID",
+                                        value: "0abcdef-123456789-abcdef",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_UNIQUE_NAME",
+                                        value: "BeechwoodPark.ts#L243",
+                                    },
+                                    {
+                                        name: "ATOMIST_CORRELATION_ID",
+                                        value: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                                    },
+                                    {
+                                        name: "ATOMIST_ISOLATED_GOAL",
+                                        value: "true",
+                                    },
+                                    {
+                                        name: "ATOMIST_ISOLATED_GOAL_INIT",
+                                        value: "true",
+                                    },
+                                ],
+                            },
+                            container: [
+                                {
+                                    args: ["true"],
+                                    env: [
+                                        {
+                                            name: "ATOMIST_SLUG",
+                                            value: "TheZombies/odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_OWNER",
+                                            value: "TheZombies",
+                                        },
+                                        {
+                                            name: "ATOMIST_REPO",
+                                            value: "odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_SHA",
+                                            value: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                                        },
+                                        {
+                                            name: "ATOMIST_BRANCH",
+                                            value: "psychedelic-rock",
+                                        },
+                                        {
+                                            name: "ATOMIST_VERSION",
+                                            value: "1968.4.19",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL_SET_ID",
+                                            value: "0abcdef-123456789-abcdef",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL",
+                                            value: "BeechwoodPark.ts#L243",
+                                        },
+                                    ],
+                                    image: "colin/blunstone:1945.6.24",
+                                    name: "colin-blunstone",
+                                },
+                            ],
+                            volume: [
+                                {
+                                    name: "home",
+                                    emptyDir: {},
+                                },
+                            ],
+                            volumeMount: [
+                                {
+                                    mountPath: "/atm/home",
+                                    name: "home",
+                                },
+                            ],
+                        },
+                    },
+                },
+            };
+            assert.deepStrictEqual(p, d);
+            delete ge.data;
+            const e = {
+                branch: "psychedelic-rock",
+                goalSetId: "0abcdef-123456789-abcdef",
+                id: "CHANGES",
+                repo: {
+                    name: "odessey-and-oracle",
+                    owner: "TheZombies",
+                    providerId: "CBS",
+                },
+                sha: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                uniqueName: "BeechwoodPark.ts#L243",
+            };
+            assert.deepStrictEqual(ge, e);
+        });
+
         it("should merge k8s service into registration and use callback", async () => {
             const r: K8sContainerRegistration = {
                 callback: async () => {
@@ -444,7 +591,7 @@ describe("goal/container/k8s", () => {
                                             name: "tempest",
                                         },
                                     ],
-                                    workingDir: "/atm/home",
+                                    workingDir: "/abbey/road",
                                 },
                                 {
                                     args: ["second"],

--- a/test/goal/container/k8s.test.ts
+++ b/test/goal/container/k8s.test.ts
@@ -1,0 +1,849 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitCommandGitProject,
+    GitProject,
+    guid,
+    InMemoryProject,
+    NodeFsLocalProject,
+} from "@atomist/automation-client";
+import {
+    execPromise,
+    ExecuteGoalResult,
+    fakePush,
+    GoalInvocation,
+    RepoContext,
+    SdmGoalEvent,
+    SdmGoalState,
+} from "@atomist/sdm";
+import * as k8s from "@kubernetes/client-node";
+import * as fs from "fs-extra";
+import * as _ from "lodash";
+import * as os from "os";
+import * as path from "path";
+import * as assert from "power-assert";
+import { DeepPartial } from "ts-essentials";
+import { Container } from "../../../lib/goal/container/container";
+import {
+    executeK8sJob,
+    K8sContainerRegistration,
+    k8sFulfillmentCallback,
+} from "../../../lib/goal/container/k8s";
+import { loadKubeConfig } from "../../../lib/pack/k8s/config";
+import { KubernetesGoalScheduler } from "../../../lib/pack/k8s/KubernetesGoalScheduler";
+import { containerTestImage } from "./util";
+
+/* tslint:disable:max-file-line-count */
+
+describe("goal/container/k8s", () => {
+
+    describe("k8sFulfillmentCallback", () => {
+
+        let rac: any;
+        let gcgpc: any;
+        before(() => {
+            rac = (global as any).__runningAutomationClient;
+            (global as any).__runningAutomationClient = {
+                configuration: {
+                    name: "@zombies/care-of-cell-44",
+                },
+            };
+            gcgpc = GitCommandGitProject.cloned;
+            GitCommandGitProject.cloned = async () => InMemoryProject.of() as any;
+        });
+        after(() => {
+            (global as any).__runningAutomationClient = rac;
+            GitCommandGitProject.cloned = gcgpc;
+        });
+
+        const g: Container = new Container();
+        const sge: SdmGoalEvent = {
+            branch: "psychedelic-rock",
+            goalSetId: "0abcdef-123456789-abcdef",
+            id: "CHANGES",
+            repo: {
+                name: "odessey-and-oracle",
+                owner: "TheZombies",
+                providerId: "CBS",
+            },
+            sha: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+            uniqueName: "BeechwoodPark.ts#L243",
+        } as any;
+        const kgs = new KubernetesGoalScheduler();
+        kgs.podSpec = {
+            spec: {
+                containers: [
+                    {
+                        image: "rod/argent:1945.6.14",
+                        name: "rod-argent",
+                    },
+                ],
+            },
+        } as any;
+        const rc: RepoContext = {
+            configuration: {
+                sdm: {
+                    goalScheduler: [kgs],
+                },
+            },
+            context: {
+                context: {
+                    workspaceName: "Odessey and Oracle",
+                },
+                correlationId: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                graphClient: {
+                    query: async () => ({ SdmVersion: [{ version: "1968.4.19" }] }),
+                },
+                workspaceId: "AR05343M1LY",
+            },
+        } as any;
+
+        it("should add k8s service to goal event data", async () => {
+            const r: K8sContainerRegistration = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: "colin/blunstone:1945.6.24",
+                        name: "colin-blunstone",
+                    },
+                ],
+                name: "MaybeAfterHesGone",
+            };
+            const c = k8sFulfillmentCallback(g, r);
+            const ge = await c(sge, rc);
+            const p = JSON.parse(ge.data);
+            const d = {
+                "@atomist/sdm/service": {
+                    MaybeAfterHesGone: {
+                        type: "@atomist/sdm/service/k8s",
+                        spec: {
+                            initContainer: {
+                                name: "atm-init",
+                                image: "rod/argent:1945.6.14",
+                                workingDir: "/atm/home",
+                                volumeMounts: [
+                                    {
+                                        mountPath: "/atm/home",
+                                        name: "home",
+                                    },
+                                ],
+                                env: [
+                                    {
+                                        name: "ATOMIST_JOB_NAME",
+                                        value: "rod-argent-job-0abcdef-beechwoodpark.ts",
+                                    },
+                                    {
+                                        name: "ATOMIST_REGISTRATION_NAME",
+                                        value: `@zombies/care-of-cell-44-job-0abcdef-beechwoodpark.ts`,
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_TEAM",
+                                        value: "AR05343M1LY",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_TEAM_NAME",
+                                        value: "Odessey and Oracle",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_ID",
+                                        value: "CHANGES",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_SET_ID",
+                                        value: "0abcdef-123456789-abcdef",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_UNIQUE_NAME",
+                                        value: "BeechwoodPark.ts#L243",
+                                    },
+                                    {
+                                        name: "ATOMIST_CORRELATION_ID",
+                                        value: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                                    },
+                                    {
+                                        name: "ATOMIST_ISOLATED_GOAL",
+                                        value: "true",
+                                    },
+                                    {
+                                        name: "ATOMIST_ISOLATED_GOAL_INIT",
+                                        value: "true",
+                                    },
+                                ],
+                            },
+                            container: [
+                                {
+                                    args: ["true"],
+                                    env: [
+                                        {
+                                            name: "ATOMIST_SLUG",
+                                            value: "TheZombies/odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_OWNER",
+                                            value: "TheZombies",
+                                        },
+                                        {
+                                            name: "ATOMIST_REPO",
+                                            value: "odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_SHA",
+                                            value: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                                        },
+                                        {
+                                            name: "ATOMIST_BRANCH",
+                                            value: "psychedelic-rock",
+                                        },
+                                        {
+                                            name: "ATOMIST_VERSION",
+                                            value: "1968.4.19",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL_SET_ID",
+                                            value: "0abcdef-123456789-abcdef",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL",
+                                            value: "BeechwoodPark.ts#L243",
+                                        },
+                                    ],
+                                    image: "colin/blunstone:1945.6.24",
+                                    name: "colin-blunstone",
+                                    workingDir: "/atm/home",
+                                },
+                            ],
+                            volume: [
+                                {
+                                    name: "home",
+                                    emptyDir: {},
+                                },
+                            ],
+                            volumeMount: [
+                                {
+                                    mountPath: "/atm/home",
+                                    name: "home",
+                                },
+                            ],
+                        },
+                    },
+                },
+            };
+            assert.deepStrictEqual(p, d);
+            delete ge.data;
+            const e = {
+                branch: "psychedelic-rock",
+                goalSetId: "0abcdef-123456789-abcdef",
+                id: "CHANGES",
+                repo: {
+                    name: "odessey-and-oracle",
+                    owner: "TheZombies",
+                    providerId: "CBS",
+                },
+                sha: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                uniqueName: "BeechwoodPark.ts#L243",
+            };
+            assert.deepStrictEqual(ge, e);
+        });
+
+        it("should throw an error if there are no containers", async () => {
+            const r: K8sContainerRegistration = {
+                containers: [],
+            };
+            const c = k8sFulfillmentCallback(g, r);
+            try {
+                await c(sge, rc);
+                assert.fail("callback should have thrown an error");
+            } catch (e) {
+                assert(/No containers defined in K8sGoalContainerSpec/.test(e.message));
+            }
+        });
+
+        it("should merge k8s service into registration and use callback", async () => {
+            const r: K8sContainerRegistration = {
+                callback: async () => {
+                    return {
+                        containers: [
+                            {
+                                args: ["first"],
+                                env: [
+                                    {
+                                        name: "GENRE",
+                                        value: "Baroque pop",
+                                    },
+                                    {
+                                        name: "STUDIO",
+                                        value: "Abbey Road",
+                                    },
+                                ],
+                                image: "colin/blunstone:1945.6.24",
+                                name: "colin-blunstone",
+                                volumeMounts: [
+                                    {
+                                        mountPath: "/willy",
+                                        name: "tempest",
+                                    },
+                                ],
+                                workingDir: "/abbey/road",
+                            },
+                            {
+                                args: ["second"],
+                                env: [
+                                    {
+                                        name: "INSTRUMENT",
+                                        value: "Bass",
+                                    },
+                                ],
+                                image: "chris/white:1943.3.7",
+                                name: "chris-white",
+                                volumeMounts: [
+                                    {
+                                        mountPath: "/bill",
+                                        name: "tempest",
+                                    },
+                                ],
+                            },
+                        ],
+                    };
+                },
+                containers: [],
+                volumes: [
+                    {
+                        hostPath: {
+                            path: "/william/shakespeare",
+                        },
+                        name: "tempest",
+                    },
+                ],
+                name: "MaybeAfterHesGone",
+            };
+            const c = k8sFulfillmentCallback(g, r);
+            const ge = await c(sge, rc);
+            const p = JSON.parse(ge.data);
+            const d = {
+                "@atomist/sdm/service": {
+                    MaybeAfterHesGone: {
+                        type: "@atomist/sdm/service/k8s",
+                        spec: {
+                            initContainer: {
+                                env: [
+                                    {
+                                        name: "ATOMIST_JOB_NAME",
+                                        value: "rod-argent-job-0abcdef-beechwoodpark.ts",
+                                    },
+                                    {
+                                        name: "ATOMIST_REGISTRATION_NAME",
+                                        value: `@zombies/care-of-cell-44-job-0abcdef-beechwoodpark.ts`,
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_TEAM",
+                                        value: "AR05343M1LY",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_TEAM_NAME",
+                                        value: "Odessey and Oracle",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_ID",
+                                        value: "CHANGES",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_SET_ID",
+                                        value: "0abcdef-123456789-abcdef",
+                                    },
+                                    {
+                                        name: "ATOMIST_GOAL_UNIQUE_NAME",
+                                        value: "BeechwoodPark.ts#L243",
+                                    },
+                                    {
+                                        name: "ATOMIST_CORRELATION_ID",
+                                        value: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                                    },
+                                    {
+                                        name: "ATOMIST_ISOLATED_GOAL",
+                                        value: "true",
+                                    },
+                                    {
+                                        name: "ATOMIST_ISOLATED_GOAL_INIT",
+                                        value: "true",
+                                    },
+                                ],
+                                image: "rod/argent:1945.6.14",
+                                name: "atm-init",
+                                volumeMounts: [
+                                    {
+                                        mountPath: "/atm/home",
+                                        name: "home",
+                                    },
+                                ],
+                                workingDir: "/atm/home",
+                            },
+                            container: [
+                                {
+                                    args: ["first"],
+                                    env: [
+                                        {
+                                            name: "ATOMIST_SLUG",
+                                            value: "TheZombies/odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_OWNER",
+                                            value: "TheZombies",
+                                        },
+                                        {
+                                            name: "ATOMIST_REPO",
+                                            value: "odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_SHA",
+                                            value: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                                        },
+                                        {
+                                            name: "ATOMIST_BRANCH",
+                                            value: "psychedelic-rock",
+                                        },
+                                        {
+                                            name: "ATOMIST_VERSION",
+                                            value: "1968.4.19",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL_SET_ID",
+                                            value: "0abcdef-123456789-abcdef",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL",
+                                            value: "BeechwoodPark.ts#L243",
+                                        },
+                                        {
+                                            name: "GENRE",
+                                            value: "Baroque pop",
+                                        },
+                                        {
+                                            name: "STUDIO",
+                                            value: "Abbey Road",
+                                        },
+                                    ],
+                                    image: "colin/blunstone:1945.6.24",
+                                    name: "colin-blunstone",
+                                    volumeMounts: [
+                                        {
+                                            mountPath: "/willy",
+                                            name: "tempest",
+                                        },
+                                    ],
+                                    workingDir: "/atm/home",
+                                },
+                                {
+                                    args: ["second"],
+                                    env: [
+                                        {
+                                            name: "ATOMIST_SLUG",
+                                            value: "TheZombies/odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_OWNER",
+                                            value: "TheZombies",
+                                        },
+                                        {
+                                            name: "ATOMIST_REPO",
+                                            value: "odessey-and-oracle",
+                                        },
+                                        {
+                                            name: "ATOMIST_SHA",
+                                            value: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                                        },
+                                        {
+                                            name: "ATOMIST_BRANCH",
+                                            value: "psychedelic-rock",
+                                        },
+                                        {
+                                            name: "ATOMIST_VERSION",
+                                            value: "1968.4.19",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL_SET_ID",
+                                            value: "0abcdef-123456789-abcdef",
+                                        },
+                                        {
+                                            name: "ATOMIST_GOAL",
+                                            value: "BeechwoodPark.ts#L243",
+                                        },
+                                        {
+                                            name: "INSTRUMENT",
+                                            value: "Bass",
+                                        },
+                                    ],
+                                    image: "chris/white:1943.3.7",
+                                    name: "chris-white",
+                                    volumeMounts: [
+                                        {
+                                            mountPath: "/bill",
+                                            name: "tempest",
+                                        },
+                                    ],
+                                },
+                            ],
+                            volume: [
+                                {
+                                    name: "home",
+                                    emptyDir: {},
+                                },
+                            ],
+                            volumeMount: [
+                                {
+                                    mountPath: "/atm/home",
+                                    name: "home",
+                                },
+                            ],
+                        },
+                    },
+                },
+            };
+            assert.deepStrictEqual(p, d);
+            delete ge.data;
+            const e = {
+                branch: "psychedelic-rock",
+                goalSetId: "0abcdef-123456789-abcdef",
+                id: "CHANGES",
+                repo: {
+                    name: "odessey-and-oracle",
+                    owner: "TheZombies",
+                    providerId: "CBS",
+                },
+                sha: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                uniqueName: "BeechwoodPark.ts#L243",
+            };
+            assert.deepStrictEqual(ge, e);
+        });
+
+    });
+
+    describe("executeK8sJob", () => {
+
+        const fakeId = fakePush().id;
+        const goal = new Container();
+        const tmpDirPrefix = path.join(os.tmpdir(), "atomist-sdm-core-k8s-test");
+        let project: GitProject;
+        const tmpDirs: string[] = [];
+        let logData = "";
+        const goalInvocation: GoalInvocation = {
+            context: {
+                graphClient: {
+                    query: () => ({ SdmVersion: [{ version: "3.1.3-20200220200220" }] }),
+                },
+            },
+            configuration: {
+                sdm: {
+                    projectLoader: {
+                        doWithProject: (o, a) => a(project),
+                    },
+                },
+            },
+            credentials: {},
+            goalEvent: {
+                branch: fakeId.branch,
+                goalSetId: "27c20de4-2c88-480a-b4e7-f6c6d5a1d623",
+                repo: {
+                    name: fakeId.repo,
+                    owner: fakeId.owner,
+                    providerId: "album",
+                },
+                sha: fakeId.sha,
+                uniqueName: goal.definition.uniqueName,
+            },
+            id: fakeId,
+            progressLog: {
+                write: d => { logData += d; },
+            },
+        } as any;
+
+        let cwd: string;
+        before(async function getCwd(): Promise<void> {
+            cwd = process.cwd();
+        });
+
+        beforeEach(async function resetFileSystem(): Promise<void> {
+            logData = "";
+            const projectDir = `${tmpDirPrefix}-${guid()}`;
+            await fs.ensureDir(projectDir);
+            tmpDirs.push(projectDir);
+            project = await NodeFsLocalProject.fromExistingDirectory(fakeId, projectDir) as any;
+            const workingDir = `${tmpDirPrefix}-${guid()}`;
+            await fs.ensureDir(workingDir);
+            tmpDirs.push(workingDir);
+            process.chdir(workingDir);
+        });
+
+        after(async function directoryCleanup(): Promise<void> {
+            await Promise.all(tmpDirs.map(d => fs.remove(d)));
+        });
+
+        afterEach(() => {
+            process.chdir(cwd);
+        });
+
+        it("should run in init mode and copy project", async () => {
+            const r = {
+                containers: [
+                    {
+                        args: ["true"],
+                        image: containerTestImage,
+                        name: "alpine",
+                    },
+                ],
+            };
+            const e = executeK8sJob(goal, r);
+            const f = `JUNK-${guid()}.md`;
+            const fp = path.join(project.baseDir, f);
+            await fs.writeFile(fp, "Counting the days until they set you free again\n");
+            assert(!fs.existsSync(f));
+            process.env.ATOMIST_ISOLATED_GOAL_INIT = "true";
+            const egr = await e(goalInvocation);
+            delete process.env.ATOMIST_ISOLATED_GOAL_INIT;
+            assert(egr, "ExecuteGoal did not return a value");
+            const x = egr as SdmGoalEvent;
+            const eg = {
+                branch: fakeId.branch,
+                goalSetId: "27c20de4-2c88-480a-b4e7-f6c6d5a1d623",
+                repo: {
+                    name: fakeId.repo,
+                    owner: fakeId.owner,
+                    providerId: "album",
+                },
+                sha: fakeId.sha,
+                state: SdmGoalState.in_process,
+                uniqueName: goal.definition.uniqueName,
+            };
+            assert.deepStrictEqual(x, eg, logData);
+            const ec = await fs.readFile(f, "utf8");
+            assert(ec === "Counting the days until they set you free again\n");
+        }).timeout(10000);
+
+        describe("minikube", () => {
+
+            const ns = "default"; // readNamespace() is going to default to "default"
+            const partialPodSpec: DeepPartial<k8s.V1Pod> = {
+                apiVersion: "v1",
+                kind: "Pod",
+                metadata: {
+                    namespace: ns,
+                },
+                spec: {
+                    restartPolicy: "Never",
+                    terminationGracePeriodSeconds: 0,
+                },
+            };
+            const podNamePrefix = "sdm-core-container-k8s-test";
+
+            let originalOsHostname: any;
+            let k8sCore: k8s.CoreV1Api;
+            before(async function minikubeCheckProjectSetup(): Promise<void> {
+                // tslint:disable-next-line:no-invalid-this
+                this.timeout(20000);
+                try {
+                    // see if minikube is available and responding
+                    await execPromise("kubectl", ["config", "use-context", "minikube"]);
+                    await execPromise("kubectl", ["get", "--request-timeout=200ms", "pods"]);
+                    const kc = loadKubeConfig();
+                    k8sCore = kc.makeApiClient(k8s.CoreV1Api);
+                } catch (e) {
+                    // tslint:disable-next-line:no-invalid-this
+                    this.skip();
+                }
+                originalOsHostname = Object.getOwnPropertyDescriptor(os, "hostname");
+            });
+
+            beforeEach(() => {
+                const podName = `${podNamePrefix}-${guid().split("-")[0]}`;
+                partialPodSpec.metadata.name = podName;
+                Object.defineProperty(os, "hostname", { value: () => podName });
+            });
+
+            after(() => {
+                if (originalOsHostname) {
+                    Object.defineProperty(os, "hostname", originalOsHostname);
+                }
+            });
+
+            afterEach(() => {
+                if (originalOsHostname) {
+                    Object.defineProperty(os, "hostname", originalOsHostname);
+                }
+            });
+
+            async function execK8sJobTest(r: K8sContainerRegistration): Promise<ExecuteGoalResult | void> {
+                const p: k8s.V1Pod = _.merge({}, partialPodSpec, { spec: r });
+                await k8sCore.createNamespacedPod(ns, p);
+                const e = executeK8sJob(goal, r);
+                const egr = await e(goalInvocation);
+                try {
+                    const body: k8s.V1DeleteOptions = { gracePeriodSeconds: 0, propagationPolicy: "Background" };
+                    await k8sCore.deleteNamespacedPod(p.metadata.name, ns, undefined, body);
+                } catch (e) { /* ignore */ }
+                return egr;
+            }
+
+            it("should report when the container succeeds", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 0, logData);
+                assert(x.message === "Container 'alpine0' completed successfully");
+            }).timeout(10000);
+
+            it("should report when the container fails", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: ["false"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 1, logData);
+                assert(x.message.startsWith("Container 'alpine0' failed:"));
+            }).timeout(10000);
+
+            it("should run multiple containers", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine1",
+                        },
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine2",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 0);
+                assert(x.message === "Container 'alpine0' completed successfully");
+            }).timeout(10000);
+
+            it("should report when main container fails", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: ["false"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine1",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 1);
+                assert(x.message.startsWith("Container 'alpine0' failed:"));
+            }).timeout(10000);
+
+            it("should ignore when sidecar container fails", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                        {
+                            args: ["false"],
+                            image: containerTestImage,
+                            name: "alpine1",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 0);
+                assert(x.message === "Container 'alpine0' completed successfully");
+            }).timeout(10000);
+
+            it("should only wait on main container", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: ["true"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                        {
+                            args: ["sleep", "20"],
+                            image: containerTestImage,
+                            name: "alpine1",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 0);
+                assert(x.message === "Container 'alpine0' completed successfully");
+            }).timeout(10000);
+
+            it("should capture the container output in the log", async () => {
+                const r = {
+                    containers: [
+                        {
+                            args: [`echo "Wouldn't it be nice"; echo 'If we were older?'`],
+                            command: ["sh", "-c"],
+                            image: containerTestImage,
+                            name: "alpine0",
+                        },
+                    ],
+                };
+                const egr = await execK8sJobTest(r);
+                assert(egr, "ExecuteGoal did not return a value");
+                const x = egr as ExecuteGoalResult;
+                assert(x.code === 0, logData);
+                assert(x.message === "Container 'alpine0' completed successfully");
+                assert(logData.includes(`Wouldn't it be nice\nIf we were older?\n`));
+            }).timeout(10000);
+
+        });
+
+    });
+
+});

--- a/test/goal/container/util.test.ts
+++ b/test/goal/container/util.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { guid } from "@atomist/automation-client";
+import {
+    SdmContext,
+    SdmGoalEvent,
+} from "@atomist/sdm";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import * as assert from "power-assert";
+import {
+    containerEnvVars,
+    copyProject,
+} from "../../../lib/goal/container/util";
+
+describe("goal/container/util", () => {
+
+    describe("containerEnvVars", () => {
+
+        it("should add k8s service to goal event data", async () => {
+            const sge: SdmGoalEvent = {
+                branch: "psychedelic-rock",
+                goalSetId: "0abcdef-123456789-abcdef",
+                repo: {
+                    name: "odessey-and-oracle",
+                    owner: "TheZombies",
+                    providerId: "CBS",
+                },
+                sha: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                uniqueName: "BeechwoodPark.ts#L243",
+            } as any;
+            const c: SdmContext = {
+                context: {
+                    graphClient: {
+                        query: async () => ({ SdmVersion: [{ version: "1968.4.19" }] }),
+                    },
+                },
+                correlationId: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                workspaceId: "AR05343M1LY",
+            } as any;
+            const ge = await containerEnvVars(sge, c);
+            const e = [
+                {
+                    name: "ATOMIST_SLUG",
+                    value: "TheZombies/odessey-and-oracle",
+                },
+                {
+                    name: "ATOMIST_OWNER",
+                    value: "TheZombies",
+                },
+                {
+                    name: "ATOMIST_REPO",
+                    value: "odessey-and-oracle",
+                },
+                {
+                    name: "ATOMIST_SHA",
+                    value: "7ee1af8ee2f80ad1e718dbb2028120b3a2984892",
+                },
+                {
+                    name: "ATOMIST_BRANCH",
+                    value: "psychedelic-rock",
+                },
+                {
+                    name: "ATOMIST_VERSION",
+                    value: "1968.4.19",
+                },
+                {
+                    name: "ATOMIST_GOAL_SET_ID",
+                    value: "0abcdef-123456789-abcdef",
+                },
+                {
+                    name: "ATOMIST_GOAL",
+                    value: "BeechwoodPark.ts#L243",
+                },
+            ];
+            assert.deepStrictEqual(ge, e);
+        });
+
+    });
+
+    describe("copyProject", () => {
+
+        const tmpDirPrefix = "atomist-sdm-core-container-util-test";
+        const tmpDirs: string[] = [];
+        after(async () => {
+            await Promise.all(tmpDirs.map(t => fs.remove(t)));
+        });
+
+        it("should copy project from one location to another", async () => {
+            const s = path.join(os.tmpdir(), `${tmpDirPrefix}-${guid()}`);
+            const d = path.join(os.tmpdir(), `${tmpDirPrefix}-${guid()}`);
+            tmpDirs.push(s, d);
+            await fs.ensureDir(s);
+            const sf = path.join(s, "FriendsOfMine.txt");
+            await fs.writeFile(sf, "This Will Be Our Year\n");
+            await copyProject(s, d);
+            const df = path.join(d, "FriendsOfMine.txt");
+            assert(fs.existsSync(df));
+            const dfc = await fs.readFile(df, "utf8");
+            assert(dfc === "This Will Be Our Year\n");
+        });
+
+        it("should copy nested and hidden files", async () => {
+            const s = path.join(os.tmpdir(), `${tmpDirPrefix}-${guid()}`);
+            const d = path.join(os.tmpdir(), `${tmpDirPrefix}-${guid()}`);
+            tmpDirs.push(s, d);
+            const n = path.join(s, "Time", "of", "the", "Season");
+            await fs.ensureDir(n);
+            const sf = path.join(s, "Time", ".FriendsOfMine.txt");
+            await fs.writeFile(sf, "This Will Be Our Year\n");
+            const sf1 = path.join(n, "Butcher's Tale.ts");
+            await fs.writeFile(sf1, "// Western Front 1914\n");
+            await copyProject(s, d);
+            const df = path.join(d, "Time", ".FriendsOfMine.txt");
+            assert(fs.existsSync(df));
+            const dfc = await fs.readFile(df, "utf8");
+            assert(dfc === "This Will Be Our Year\n");
+            const df1 = path.join(d, "Time", "of", "the", "Season", "Butcher's Tale.ts");
+            assert(fs.existsSync(df1));
+            const dfc1 = await fs.readFile(df1, "utf8");
+            assert(dfc1 === "// Western Front 1914\n");
+        });
+
+        it("should clean destination project", async () => {
+            const s = path.join(os.tmpdir(), `${tmpDirPrefix}-${guid()}`);
+            const d = path.join(os.tmpdir(), `${tmpDirPrefix}-${guid()}`);
+            tmpDirs.push(s, d);
+            await fs.ensureDir(s);
+            await fs.ensureDir(d);
+            const sf = path.join(s, "FriendsOfMine.txt");
+            await fs.writeFile(sf, "This Will Be Our Year\n");
+            const dx = path.join(d, "README.md");
+            await fs.writeFile(dx, "# Hung Up on a Dream\n");
+            assert(fs.existsSync(dx));
+            await copyProject(s, d);
+            const df = path.join(d, "FriendsOfMine.txt");
+            assert(fs.existsSync(df));
+            const dfc = await fs.readFile(df, "utf8");
+            assert(dfc === "This Will Be Our Year\n");
+            assert(!fs.existsSync(dx));
+        });
+
+    });
+
+});

--- a/test/goal/container/util.ts
+++ b/test/goal/container/util.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const containerTestImage = "alpine:3.9.4";

--- a/test/mapping/pushtest/toPublicRepo.test.ts
+++ b/test/mapping/pushtest/toPublicRepo.test.ts
@@ -36,12 +36,12 @@ describe("pushToPublicRepo", () => {
         const id = new GitHubRepoRef("atomist", "sdm");
         const r = await ToPublicRepo.mapping({ id, credentials } as any as PushListenerInvocation);
         assert.equal(r, true);
-    }).timeout(5000);
+    }).timeout(8000);
 
     it("should work against private repo", async () => {
         const id = new GitHubRepoRef("atomisthq", "internal-automation");
         const r = await ToPublicRepo.mapping({ id, credentials } as any as PushListenerInvocation);
         assert.equal(r, false);
-    }).timeout(5000);
+    }).timeout(8000);
 
 });

--- a/test/pack/k8s/KubernetesGoalScheduler.test.ts
+++ b/test/pack/k8s/KubernetesGoalScheduler.test.ts
@@ -14,8 +14,15 @@
  * limitations under the License.
  */
 
+import * as ac from "@atomist/automation-client";
+import { SdmGoalEvent } from "@atomist/sdm";
+import * as k8s from "@kubernetes/client-node";
 import * as assert from "power-assert";
-import { isConfiguredInEnv } from "../../../lib/pack/k8s/KubernetesGoalScheduler";
+import {
+    isConfiguredInEnv,
+    k8sJobEnv,
+    k8sJobName,
+} from "../../../lib/pack/k8s/KubernetesGoalScheduler";
 
 describe("KubernetesGoalScheduler", () => {
 
@@ -65,6 +72,148 @@ describe("KubernetesGoalScheduler", () => {
         it("should detect multiple json array string value", () => {
             process.env.ATOMIST_GOAL_SCHEDULER = "[\"kubernetes-all\", \"docker\"]";
             assert(isConfiguredInEnv("docker", "kubernetes"));
+        });
+
+    });
+
+    describe("k8sJobName", () => {
+
+        it("should return a job name", () => {
+            const p: k8s.V1Pod = {
+                spec: {
+                    containers: [
+                        {
+                            name: "wild-horses",
+                        },
+                    ],
+                },
+            } as any;
+            const g: SdmGoalEvent = {
+                goalSetId: "abcdef0-123456789-abcdef",
+                uniqueName: "Sundown.ts#L74",
+            } as any;
+            const n = k8sJobName(p, g);
+            const e = "wild-horses-job-abcdef0-sundown.ts";
+            assert(n === e);
+        });
+
+        it("should truncate a long job name", () => {
+            const p: k8s.V1Pod = {
+                spec: {
+                    containers: [
+                        {
+                            name: "whos-gonna-ride-your-wild-horses",
+                        },
+                    ],
+                },
+            } as any;
+            const g: SdmGoalEvent = {
+                goalSetId: "abcdef0-123456789-abcdef",
+                uniqueName: "SomewhereNorthOfNashville.ts#L74",
+            } as any;
+            const n = k8sJobName(p, g);
+            const e = "whos-gonna-ride-your-wild-horses-job-abcdef0-somewherenorthofna";
+            assert(n === e);
+        });
+
+        it("should safely truncate a long job name", () => {
+            const p: k8s.V1Pod = {
+                spec: {
+                    containers: [
+                        {
+                            name: "i-think-theyve-got-your-alias-youve-been-living-un",
+                        },
+                    ],
+                },
+            } as any;
+            const g: SdmGoalEvent = {
+                goalSetId: "abcdef0-123456789-abcdef",
+                uniqueName: "SomewhereNorthOfNashville.ts#L74",
+            } as any;
+            const n = k8sJobName(p, g);
+            const e = "i-think-theyve-got-your-alias-youve-been-living-un-job-abcdef0";
+            assert(n === e);
+        });
+
+    });
+
+    describe("k8sJobEnv", () => {
+
+        let aci: any;
+        before(() => {
+            aci = (global as any).__runningAutomationClient;
+            (global as any).__runningAutomationClient = {
+                configuration: {
+                    name: "@zombies/care-of-cell-44",
+                },
+            };
+        });
+        after(() => {
+            (global as any).__runningAutomationClient = aci;
+        });
+
+        it("should produce a valid set of environment variables", () => {
+            const p: k8s.V1Pod = {
+                spec: {
+                    containers: [
+                        {
+                            name: "brief-candles",
+                        },
+                    ],
+                },
+            } as any;
+            const g: SdmGoalEvent = {
+                goalSetId: "0abcdef-123456789-abcdef",
+                id: "CHANGES",
+                uniqueName: "BeechwoodPark.ts#L243",
+            } as any;
+            const c: ac.HandlerContext = {
+                context: {
+                    workspaceName: "Odessey and Oracle",
+                },
+                correlationId: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                workspaceId: "AR05343M1LY",
+            } as any;
+            const v = k8sJobEnv(p, g, c);
+            const e = [
+                {
+                    name: "ATOMIST_JOB_NAME",
+                    value: "brief-candles-job-0abcdef-beechwoodpark.ts",
+                },
+                {
+                    name: "ATOMIST_REGISTRATION_NAME",
+                    value: `@zombies/care-of-cell-44-job-0abcdef-beechwoodpark.ts`,
+                },
+                {
+                    name: "ATOMIST_GOAL_TEAM",
+                    value: "AR05343M1LY",
+                },
+                {
+                    name: "ATOMIST_GOAL_TEAM_NAME",
+                    value: "Odessey and Oracle",
+                },
+                {
+                    name: "ATOMIST_GOAL_ID",
+                    value: "CHANGES",
+                },
+                {
+                    name: "ATOMIST_GOAL_SET_ID",
+                    value: "0abcdef-123456789-abcdef",
+                },
+                {
+                    name: "ATOMIST_GOAL_UNIQUE_NAME",
+                    value: "BeechwoodPark.ts#L243",
+                },
+                {
+                    name: "ATOMIST_CORRELATION_ID",
+                    value: "fedcba9876543210-0123456789abcdef-f9e8d7c6b5a43210",
+                },
+                {
+                    name: "ATOMIST_ISOLATED_GOAL",
+                    value: "true",
+                },
+            ];
+            assert.deepStrictEqual(v, e);
         });
 
     });


### PR DESCRIPTION
Add container goal definition and working schedulers for Kubernetes
jobs and Docker CLI.  Use first container as goal container, which
means it is the only one waited on and its status sets the goal
status.  Will throw error if no containers defined.

Co-opt KubernetesGoalScheduler for k8s container goal implementation,
extracting some of its functionality into functions that can be used
to define the init container.  Collect logs from k8s into goal
progress log, adding a delay because log delivery from the k8s API can
occur after the container terminates.  Add tests for some scheduler
and environment variable functionality.

Add CacheEntry interface and do some minor clean up to caching
interface.  Correct goal caching restore interface to only require
options it uses.  Clean up cache tests.

Properly handle project directory and cache use by copying its
contents to a location usable by container, mounting that location in
the container, setting the working directory in the first container to
that location, and copying the contents back after the containers
exit.

Closes #162