### PR TITLE
Add initial support for jobs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -115,6 +115,12 @@ export {
     exposeInfo,
     infoSupport,
 } from "./lib/pack/info/exposeInfo";
+export {
+    jobSupport,
+} from "./lib/pack/job/job";
+export {
+    createJob,
+} from "./lib/pack/job/createJob";
 export { github };
 export {
     tagRepo,

--- a/lib/graphql/mutation/CreateJob.graphql
+++ b/lib/graphql/mutation/CreateJob.graphql
@@ -1,0 +1,19 @@
+mutation CreateJob(
+  $data: String!
+  $name: String!
+  $description: String!
+  $owner: String!
+  $tasks: [AtmJobTaskInput!]!
+) {
+  createAtmJob(
+    jobInput: {
+      data: $data
+      name: $name
+      description: $description
+      owner: $owner
+      jobTasks: $tasks
+    }
+  ) {
+    id
+  }
+}

--- a/lib/graphql/mutation/SetJobTaskState.graphql
+++ b/lib/graphql/mutation/SetJobTaskState.graphql
@@ -1,0 +1,5 @@
+mutation SetJobTaskState($id: ID!, $state: AtmJobTaskStateInput!) {
+  setAtmJobTaskState(id: $id, jobTaskState: $state) {
+    id
+  }
+}

--- a/lib/graphql/schema.json
+++ b/lib/graphql/schema.json
@@ -8236,6 +8236,16 @@
                 "defaultValue": null
               },
               {
+                "name": "owner",
+                "description": "The owner of AtmJobs to match",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "state",
                 "description": "The state of AtmJobs to match",
                 "type": {
@@ -8279,6 +8289,16 @@
               {
                 "name": "name",
                 "description": "The name of AtmJobsTasks to match",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "owner",
+                "description": "The owner of the parent AtmJob",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -10202,12 +10222,12 @@
             "deprecationReason": null
           },
           {
-            "name": "Feedback",
-            "description": "Auto-generated query for Feedback",
+            "name": "AtomistLog",
+            "description": "Auto-generated query for AtomistLog",
             "args": [
               {
                 "name": "id",
-                "description": "The ID of this Feedback",
+                "description": "The ID of this AtomistLog",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -10286,8 +10306,22 @@
                 "defaultValue": null
               },
               {
-                "name": "email",
-                "description": null,
+                "name": "timestamp",
+                "description": "Status timestamp",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "team_id",
+                "description": "Team ID for which log message is produced",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -10300,8 +10334,8 @@
                 "defaultValue": null
               },
               {
-                "name": "invocation_id",
-                "description": null,
+                "name": "level",
+                "description": "Log message level: debug, info, warn, error, fatal",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -10315,7 +10349,21 @@
               },
               {
                 "name": "message",
-                "description": null,
+                "description": "Log message",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "category",
+                "description": "Grouping, namespace etc.",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -10333,327 +10381,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "Feedback",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ManifestoSignature",
-            "description": "Auto-generated query for ManifestoSignature",
-            "args": [
-              {
-                "name": "id",
-                "description": "The ID of this ManifestoSignature",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_offset",
-                "description": "Paging offset (default 0)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_first",
-                "description": "Return the first X results (default 10)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_orderBy",
-                "description": "Name of property to sort on",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_after",
-                "description": "Search only after this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_before",
-                "description": "Search only before this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_ordering",
-                "description": "Direction of ordering",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "_Ordering",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_search",
-                "description": "Elastic Search simple full text search syntax",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "email",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "user",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "userName",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "user_id",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ManifestoSignature",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PodDeployment",
-            "description": "Auto-generated query for PodDeployment",
-            "args": [
-              {
-                "name": "id",
-                "description": "The ID of this PodDeployment",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_offset",
-                "description": "Paging offset (default 0)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_first",
-                "description": "Return the first X results (default 10)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_orderBy",
-                "description": "Name of property to sort on",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_after",
-                "description": "Search only after this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_before",
-                "description": "Search only before this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_ordering",
-                "description": "Direction of ordering",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "_Ordering",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_search",
-                "description": "Elastic Search simple full text search syntax",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "deploymentName",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "environment",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "imageTag",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "previousSha",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "sha",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "targetReplicas",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "timestamp",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PodDeployment",
+                "name": "AtomistLog",
                 "ofType": null
               }
             },
@@ -11000,354 +10728,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Notification",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SentryAlert",
-            "description": "Auto-generated query for SentryAlert",
-            "args": [
-              {
-                "name": "id",
-                "description": "The ID of this SentryAlert",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_offset",
-                "description": "Paging offset (default 0)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_first",
-                "description": "Return the first X results (default 10)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_orderBy",
-                "description": "Name of property to sort on",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_after",
-                "description": "Search only after this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_before",
-                "description": "Search only before this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_ordering",
-                "description": "Direction of ordering",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "_Ordering",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_search",
-                "description": "Elastic Search simple full text search syntax",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "culprit",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "level",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "message",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "project",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "project_name",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "url",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SentryAlert",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "AtomistLog",
-            "description": "Auto-generated query for AtomistLog",
-            "args": [
-              {
-                "name": "id",
-                "description": "The ID of this AtomistLog",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_offset",
-                "description": "Paging offset (default 0)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_first",
-                "description": "Return the first X results (default 10)",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_orderBy",
-                "description": "Name of property to sort on",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_after",
-                "description": "Search only after this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_before",
-                "description": "Search only before this timestamp",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_ordering",
-                "description": "Direction of ordering",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "_Ordering",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "_search",
-                "description": "Elastic Search simple full text search syntax",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "timestamp",
-                "description": "Status timestamp",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "team_id",
-                "description": "Team ID for which log message is produced",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "level",
-                "description": "Log message level: debug, info, warn, error, fatal",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "message",
-                "description": "Log message",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "category",
-                "description": "Grouping, namespace etc.",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AtomistLog",
                 "ofType": null
               }
             },
@@ -14301,6 +13681,30 @@
             "type": {
               "kind": "ENUM",
               "name": "OwnerType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "avatarUrl",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -22443,107 +21847,6 @@
                     "ofType": null
                   }
                 }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sentryAlerts",
-            "description": null,
-            "args": [
-              {
-                "name": "culprit",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "level",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "message",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "project",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "project_name",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "url",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SentryAlert",
-                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -34193,326 +33496,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "SentryAlert",
-        "description": null,
-        "fields": [
-          {
-            "name": "commit",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Commit",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "culprit",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "event",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "SentryEvent",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "level",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "project",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "project_name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "The ID of this SentryAlert",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SentryEvent",
-        "description": null,
-        "fields": [
-          {
-            "name": "event_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "extra",
-            "description": null,
-            "args": [
-              {
-                "name": "git_sha",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "SentryEventExtra",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SentryEventExtra",
-        "description": null,
-        "fields": [
-          {
-            "name": "artifact",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "correlation_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "environment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "git_owner",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "git_repo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "git_sha",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "invocation_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "operation_name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "operation_type",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "team_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "team_name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "version",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "_BranchOrdering",
         "description": "Ordering Enum for Branch",
@@ -37724,7 +36707,7 @@
         "fields": [
           {
             "name": "completedAt",
-            "description": "An ISO8601 timestamp set by the API when the AtmJob is set to any state other than created or running",
+            "description": "An ISO8601 timestamp set by the API when the AtmJob was considered complete (when all tasks were complete)",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37762,6 +36745,30 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "data",
+            "description": "Used to store additional information about this AtmJob",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": "A description for this AtmJob",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -37839,6 +36846,18 @@
             "deprecationReason": null
           },
           {
+            "name": "owner",
+            "description": "The owner of this job. Clients may use this in a subscription to avoid all clients subscribing to all tasks in a team.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "state",
             "description": "The AtmJobState of this AtmJob",
             "args": [],
@@ -37883,7 +36902,7 @@
         "fields": [
           {
             "name": "completedAt",
-            "description": "An ISO8601 timestamp set by the API when the AtmJobTask is set to any state other than created or running",
+            "description": "An ISO8601 timestamp set by the API when the AtmJobTask was considered complete",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -37947,6 +36966,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "job",
+            "description": "The owning job",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AtmJob",
                 "ofType": null
               }
             },
@@ -39390,12 +38425,24 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Feedback",
-        "description": null,
+        "name": "AtomistLog",
+        "description": "Atomist log messages",
         "fields": [
           {
-            "name": "email",
-            "description": null,
+            "name": "timestamp",
+            "description": "Status timestamp",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "team_id",
+            "description": "Team ID for which log message is produced",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -39406,8 +38453,8 @@
             "deprecationReason": null
           },
           {
-            "name": "invocation_id",
-            "description": null,
+            "name": "level",
+            "description": "Log message level: debug, info, warn, error, fatal",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -39419,7 +38466,7 @@
           },
           {
             "name": "message",
-            "description": null,
+            "description": "Log message",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -39430,8 +38477,43 @@
             "deprecationReason": null
           },
           {
+            "name": "category",
+            "description": "Grouping, namespace etc.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "correlation_context",
+            "description": "Atomist log correlation context",
+            "args": [
+              {
+                "name": "correlation_id",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AtomistLogCorrelationContext",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
-            "description": "The ID of this Feedback",
+            "description": "The ID of this AtomistLog",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -39449,12 +38531,12 @@
       },
       {
         "kind": "OBJECT",
-        "name": "ManifestoSignature",
-        "description": null,
+        "name": "AtomistLogCorrelationContext",
+        "description": "Atomist log correlation context",
         "fields": [
           {
-            "name": "email",
-            "description": null,
+            "name": "correlation_id",
+            "description": "Correlation ID",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -39465,48 +38547,33 @@
             "deprecationReason": null
           },
           {
-            "name": "user",
-            "description": null,
-            "args": [],
+            "name": "automation",
+            "description": "Automation for which log message is produced",
+            "args": [
+              {
+                "name": "name",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "version",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "user_id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "The ID of this ManifestoSignature",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
+              "kind": "OBJECT",
+              "name": "AtomistLogAutomation",
               "ofType": null
             },
             "isDeprecated": false,
@@ -39520,128 +38587,28 @@
       },
       {
         "kind": "OBJECT",
-        "name": "PodDeployment",
-        "description": null,
+        "name": "AtomistLogAutomation",
+        "description": "Automation for which log message is produced",
         "fields": [
           {
-            "name": "deploymentName",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "environment",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "imageTag",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "previousSha",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sha",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "targetReplicas",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "timestamp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "The ID of this PodDeployment",
+            "name": "name",
+            "description": "Automation name",
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "ID",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "version",
+            "description": "Automation description",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -41411,203 +40378,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AtomistLog",
-        "description": "Atomist log messages",
-        "fields": [
-          {
-            "name": "timestamp",
-            "description": "Status timestamp",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "team_id",
-            "description": "Team ID for which log message is produced",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "level",
-            "description": "Log message level: debug, info, warn, error, fatal",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": "Log message",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "category",
-            "description": "Grouping, namespace etc.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "correlation_context",
-            "description": "Atomist log correlation context",
-            "args": [
-              {
-                "name": "correlation_id",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "AtomistLogCorrelationContext",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "The ID of this AtomistLog",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AtomistLogCorrelationContext",
-        "description": "Atomist log correlation context",
-        "fields": [
-          {
-            "name": "correlation_id",
-            "description": "Correlation ID",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "automation",
-            "description": "Automation for which log message is produced",
-            "args": [
-              {
-                "name": "name",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "version",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "AtomistLogAutomation",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AtomistLogAutomation",
-        "description": "Automation for which log message is produced",
-        "fields": [
-          {
-            "name": "name",
-            "description": "Automation name",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "version",
-            "description": "Automation description",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -44462,6 +43232,26 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "data",
+            "description": "Used to store additional information about this AtmJob",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "description",
+            "description": "A description for this job.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "jobTasks",
             "description": "",
             "type": {
@@ -44494,6 +43284,16 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "owner",
+            "description": "The owner of this job. Clients may use this in a subscription to avoid all clients subscribing to all tasks in a team.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null
           }
@@ -52808,6 +51608,16 @@
                 "defaultValue": null
               },
               {
+                "name": "owner",
+                "description": "The owner of AtmJobs to match",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
                 "name": "state",
                 "description": "The state of AtmJobs to match",
                 "type": {
@@ -52851,6 +51661,16 @@
               {
                 "name": "name",
                 "description": "The name of AtmJobsTasks to match",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "owner",
+                "description": "The owner of the parent AtmJob",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -53803,12 +52623,26 @@
             "deprecationReason": null
           },
           {
-            "name": "Feedback",
-            "description": "Auto-generated subscription for Feedback",
+            "name": "AtomistLog",
+            "description": "Auto-generated subscription for AtomistLog",
             "args": [
               {
-                "name": "email",
-                "description": null,
+                "name": "timestamp",
+                "description": "Status timestamp",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "team_id",
+                "description": "Team ID for which log message is produced",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -53821,8 +52655,8 @@
                 "defaultValue": null
               },
               {
-                "name": "invocation_id",
-                "description": null,
+                "name": "level",
+                "description": "Log message level: debug, info, warn, error, fatal",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -53836,7 +52670,21 @@
               },
               {
                 "name": "message",
-                "description": null,
+                "description": "Log message",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "category",
+                "description": "Grouping, namespace etc.",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -53854,167 +52702,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "Feedback",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ManifestoSignature",
-            "description": "Auto-generated subscription for ManifestoSignature",
-            "args": [
-              {
-                "name": "email",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "user",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "userName",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "user_id",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ManifestoSignature",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PodDeployment",
-            "description": "Auto-generated subscription for PodDeployment",
-            "args": [
-              {
-                "name": "deploymentName",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "environment",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "imageTag",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "previousSha",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "sha",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "targetReplicas",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "timestamp",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PodDeployment",
+                "name": "AtomistLog",
                 "ofType": null
               }
             },
@@ -54201,194 +52889,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Notification",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SentryAlert",
-            "description": "Auto-generated subscription for SentryAlert",
-            "args": [
-              {
-                "name": "culprit",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "level",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "message",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "project",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "project_name",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "url",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SentryAlert",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "AtomistLog",
-            "description": "Auto-generated subscription for AtomistLog",
-            "args": [
-              {
-                "name": "timestamp",
-                "description": "Status timestamp",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "team_id",
-                "description": "Team ID for which log message is produced",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "level",
-                "description": "Log message level: debug, info, warn, error, fatal",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "message",
-                "description": "Log message",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "category",
-                "description": "Grouping, namespace etc.",
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AtomistLog",
                 "ofType": null
               }
             },

--- a/lib/graphql/subscription/OnAnyJobTask.graphql
+++ b/lib/graphql/subscription/OnAnyJobTask.graphql
@@ -1,0 +1,13 @@
+subscription OnAnyJobTask($registration: String) {
+  AtmJobTask(owner: $registration) {
+    id
+    data
+    name
+    job {
+      id
+      data
+    }
+    state
+    message
+  }
+}

--- a/lib/machine/machineFactory.ts
+++ b/lib/machine/machineFactory.ts
@@ -22,6 +22,7 @@ import {
 } from "@atomist/sdm";
 import { HandlerBasedSoftwareDeliveryMachine } from "../internal/machine/HandlerBasedSoftwareDeliveryMachine";
 import { infoSupport } from "../pack/info/exposeInfo";
+import { jobSupport } from "../pack/job/job";
 
 /**
  * Create a **Software Delivery MachineConfiguration** with default predefined goals.
@@ -66,7 +67,7 @@ export function createSoftwareDeliveryMachine(config: MachineConfiguration<Softw
     : SoftwareDeliveryMachine<SoftwareDeliveryMachineConfiguration> {
     const machine = new HandlerBasedSoftwareDeliveryMachine(config.name, config.configuration,
         goalSetters);
-    machine.addExtensionPacks(infoSupport());
+    machine.addExtensionPacks(infoSupport(), jobSupport());
 
     return machine;
 }

--- a/lib/pack/job/createJob.ts
+++ b/lib/pack/job/createJob.ts
@@ -41,11 +41,11 @@ export interface JobTask<T extends ParameterType> {
  * Details of the job to create
  */
 export interface JobDetails<T extends ParameterType> {
-    command: string | CommandRegistration<T>
-    registration?: string,
-    parameters: T | T[],
-    name?: string,
-    description?: string,
+    command: string | CommandRegistration<T>;
+    registration?: string;
+    parameters: T | T[];
+    name?: string;
+    description?: string;
 }
 
 /**
@@ -59,7 +59,7 @@ export interface JobDetails<T extends ParameterType> {
  * name: optional name of the job
  * description: optional description of the job used to display to the user in chat or web
  */
-export async function createJob<T extends ParameterType>(details:JobDetails<T>,
+export async function createJob<T extends ParameterType>(details: JobDetails<T>,
                                                          ctx: HandlerContext): Promise<{ id: string }> {
 
     const { command, parameters, name, description, registration } = details;

--- a/lib/pack/job/createJob.ts
+++ b/lib/pack/job/createJob.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    configurationValue,
+    HandlerContext,
+    MutationNoCacheOptions,
+    ParameterType,
+} from "@atomist/automation-client";
+import {
+    CommandRegistration,
+} from "@atomist/sdm";
+import { codeLine } from "@atomist/slack-messages";
+import * as _ from "lodash";
+import { CreateJob } from "../../typings/types";
+import { toArray } from "../../util/misc/array";
+
+export enum JobTaskType {
+    Command = "command",
+}
+
+export interface JobTask<T extends ParameterType> {
+    type: JobTaskType;
+    parameters: T;
+}
+
+/**
+ * Details of the job to create
+ */
+export interface JobDetails<T extends ParameterType> {
+    command: string | CommandRegistration<T>
+    registration?: string,
+    parameters: T | T[],
+    name?: string,
+    description?: string,
+}
+
+/**
+ * Create a Job in the backend with the provided name and tasks
+ *
+ * A job can execute any registered command in the same or other connected SDM:
+ *
+ * command: name of the CommandRegistration or the registration instance itself
+ * registration: optional name of the SDM this job should be send to; defaults to the current SDM
+ * parameters: Record type with all required parameters for this command
+ * name: optional name of the job
+ * description: optional description of the job used to display to the user in chat or web
+ */
+export async function createJob<T extends ParameterType>(details:JobDetails<T>,
+                                                         ctx: HandlerContext): Promise<{ id: string }> {
+
+    const { command, parameters, name, description, registration } = details;
+
+    const owner = registration || configurationValue<string>("name");
+    const data = JSON.stringify(_.get(ctx, "trigger") || {});
+    const cmd = typeof command === "string" ? command : command.name;
+
+    const result = await ctx.graphClient.mutate<CreateJob.Mutation, CreateJob.Variables>({
+        name: "CreateJob",
+        variables: {
+            name: !!name ? name : cmd,
+            description: !!description ? description : `Executing ${codeLine(cmd)}`,
+            owner,
+            data,
+            tasks: toArray(parameters).map(p => ({
+                name: cmd,
+                data: JSON.stringify({
+                    type: JobTaskType.Command,
+                    parameters: p,
+                }),
+            })),
+        },
+        options: MutationNoCacheOptions,
+    });
+
+    return { id: result.createAtmJob.id };
+}

--- a/lib/pack/job/executeTask.ts
+++ b/lib/pack/job/executeTask.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    automationClientInstance,
+    CommandInvocation,
+    GraphQL,
+    HandlerContext,
+    logger,
+    MessageOptions,
+    OnEvent,
+    ParameterType,
+    SourceDestination,
+    Success,
+} from "@atomist/automation-client";
+import { isCommandIncoming } from "@atomist/automation-client/lib/internal/transport/RequestProcessor";
+import { CommandHandlerMetadata } from "@atomist/automation-client/lib/metadata/automationMetadata";
+import { redact } from "@atomist/automation-client/lib/util/redact";
+import {
+    EventHandlerRegistration,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
+import {
+    AtmJobTaskState,
+    OnAnyJobTask,
+    SetJobTaskState,
+} from "../../typings/types";
+import {
+    JobTask,
+    JobTaskType,
+} from "./createJob";
+
+/**
+ * Execute an incoming job task event
+ */
+export function executeTask(sdm: SoftwareDeliveryMachine): EventHandlerRegistration<OnAnyJobTask.Subscription> {
+    return {
+        name: "ExecuteTask",
+        description: "Execute a job task",
+        subscription: GraphQL.subscription({
+            name: "OnAnyJobTask",
+            variables: {
+                registration: sdm.configuration.name,
+            },
+        }),
+        listener: ExecuteTaskListener,
+    };
+}
+
+export const ExecuteTaskListener: OnEvent<OnAnyJobTask.Subscription> = async (e, ctx) => {
+    const task = e.data.AtmJobTask[0];
+
+    if (task.state === AtmJobTaskState.created) {
+        let jobData: any;
+        let taskData: JobTask<any>;
+
+        try {
+            jobData = JSON.parse(task.job.data);
+            taskData = JSON.parse(task.data) as JobTask<any>;
+        } catch (e) {
+            logger.warn("Parsing of job or task data failed: %s", e.message);
+            await updateJobTaskState(
+                task.id,
+                AtmJobTaskState.failed,
+                redact(`Task command '${task.name}' failed: ${e.message}`),
+                ctx);
+        }
+
+        if (taskData.type === JobTaskType.Command) {
+            const md = automationClientInstance().automationServer.automations.commands
+                .find(c => c.name === task.name);
+
+            if (!md) {
+                await updateJobTaskState(
+                    task.id,
+                    AtmJobTaskState.failed,
+                    `Task command '${task.name}' could not be found`,
+                    ctx);
+            } else {
+                try {
+                    // Invoke the command
+                    const result = await automationClientInstance().automationServer.invokeCommand(
+                        prepareCommandInvocation(md, taskData.parameters),
+                        prepareHandlerContext(ctx, jobData),
+                    );
+
+                    // Handle result
+                    if (!!result && result.code !== undefined) {
+                        if (result.code === 0) {
+                            await updateJobTaskState(
+                                task.id,
+                                AtmJobTaskState.success,
+                                `Task command '${task.name}' successfully executed`,
+                                ctx);
+                        } else {
+                            await updateJobTaskState(
+                                task.id,
+                                AtmJobTaskState.failed,
+                                redact(result.message || `Task command '${task.name}' failed`),
+                                ctx);
+                        }
+                    } else {
+                        await updateJobTaskState(
+                            task.id,
+                            AtmJobTaskState.success,
+                            `Task command '${task.name}' successfully executed`,
+                            ctx);
+                    }
+                } catch (e) {
+                    logger.warn("Command execution failed: %s", e.message);
+                    await updateJobTaskState(
+                        task.id,
+                        AtmJobTaskState.failed,
+                        redact(`Task command '${task.name}' failed: ${e.message}`),
+                        ctx);
+                }
+            }
+        }
+    }
+
+    return Success;
+};
+
+/**
+ * Update the job task status
+ */
+async function updateJobTaskState(id: string,
+                                  state: AtmJobTaskState,
+                                  message: string,
+                                  ctx: HandlerContext): Promise<void> {
+    await ctx.graphClient.mutate<SetJobTaskState.Mutation, SetJobTaskState.Variables>({
+        name: "SetJobTaskState",
+        variables: {
+            id,
+            state: {
+                state,
+                message,
+            },
+        },
+    });
+}
+
+/**
+ * Prepare the CommandInvocation instance to be sent for execution
+ *
+ * This pieces apart provided values form the parameters into the command's parameter, mapped parameter
+ * and secret structures.
+ */
+function prepareCommandInvocation(md: CommandHandlerMetadata, parameters: ParameterType = {}): CommandInvocation {
+    const ci: CommandInvocation = {
+        name: md.name,
+        args: md.parameters.filter(p => !!parameters[p.name]).map(p => ({
+            name: p.name,
+            value: parameters[p.name] as any,
+        })),
+        mappedParameters: md.mapped_parameters.filter(p => !!parameters[p.name]).map(p => ({
+            name: p.name,
+            value: parameters[p.name] as any,
+        })),
+        secrets: md.secrets.filter(p => !!parameters[p.name]).map(p => ({
+            uri: p.uri,
+            value: parameters[p.name] as any,
+        })),
+    };
+    return ci;
+}
+
+/**
+ * Decorate the HandlerContext to support response messages for this event handler invocation.
+ *
+ * Task execution happens is rooted in an event handler executing; this would prevent response
+ * messages to work out of the box which is why this function adds the respond function to the
+ * MessageClient if possible.
+ */
+function prepareHandlerContext(ctx: HandlerContext, trigger: any): HandlerContext {
+    if (isCommandIncoming(trigger)) {
+        const source = trigger.source;
+        if (!!source) {
+            ctx.messageClient.respond = (msg: any, options?: MessageOptions) => {
+                return ctx.messageClient.send(msg, new SourceDestination(source, source.user_agent), options);
+            };
+        }
+    }
+    return ctx;
+}

--- a/lib/pack/job/job.ts
+++ b/lib/pack/job/job.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ExtensionPack,
+    metadata,
+} from "@atomist/sdm";
+import { executeTask } from "./executeTask";
+
+/**
+ * Extension pack installing job execution support into
+ * the SDM
+ *
+ * This extension pack is installed by default.
+ */
+export function jobSupport(): ExtensionPack {
+    return {
+        ...metadata("job"),
+        configure: sdm => {
+            sdm.addEvent(executeTask(sdm));
+        },
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "@atomist/automation-client": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.5.3.tgz",
-      "integrity": "sha512-3fRNtfWAJG2nUMAgpM+ZYkybclcd+AxpZsMe8CgBRoGQShDTZdMHF8ZXyEC5oot9fcn8ixYT6qTk2n9vVEGaXQ==",
+      "version": "1.5.4-master.20190618091503",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.5.4-master.20190618091503.tgz",
+      "integrity": "sha512-b042WutpSxLhM1vSVjGYdk2Wiw+wLsHEJDYPwNbHEf9bj3GGESCoR1Petc126TEqdywHxYueB5i4E4LQdV+7YQ==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^1.2.0",
@@ -215,9 +215,9 @@
           }
         },
         "ws": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
-          "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
+          "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
           "dev": true,
           "requires": {
             "async-limiter": "^1.0.0"
@@ -418,9 +418,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -517,9 +517,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.13.tgz",
-      "integrity": "sha512-zkO8hRd5Sjl7a+GM9ZMNHLD8rneAPjFBFjkAwLPs/hEv72RnFeWSyW6eE1nDbKVzMyDUYmmWNQFp0lQuwhHCdA==",
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.14.tgz",
+      "integrity": "sha512-R9gat0yUjamDVd4trvFgjlx2XYuMz1nM0uEBFP6nR1zOQAwJ3E1zqYbsVlCMWiUDGjU1hYmudmK7IjAxDUoqDw==",
       "dev": true,
       "requires": {
         "@oclif/errors": "^1.2.2",
@@ -538,9 +538,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -565,9 +565,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -603,9 +603,9 @@
       }
     },
     "@oclif/plugin-autocomplete": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.1.0.tgz",
-      "integrity": "sha512-Dz2dGyBoOUcv6/gqr9qaG7KTIkYxILL0MvMVwlhkS0f6UqCsh8fC3adYTr8BeIPQmUqWkACtC7bYp9DyQ8m2Jw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-0.1.1.tgz",
+      "integrity": "sha512-LndD8DmtV9oiYXcdumGMCaNwoEHAuyPS5o6aD2yll5VMgTA4TgTW6McxU+oEgLwkraXXK7unT9P0qJQJ6n/sbA==",
       "dev": true,
       "requires": {
         "@oclif/command": "^1.4.31",
@@ -641,12 +641,12 @@
       }
     },
     "@oclif/plugin-help": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.1.6.tgz",
-      "integrity": "sha512-M4kTERpPWNSM1Mga7K/zo9DWHLCVf2FRaIeXPoytmTPd+0kSvG3TR0Vc1bwx9/cxXoYyYGgEejwNlrfayr8FZw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.0.tgz",
+      "integrity": "sha512-56iIgE7NQfwy/ZrWrvrEfJGb5rrMUt409yoQGw4feiU101UudA1btN1pbUbcKBr7vY9KFeqZZcftXEGxOp7zBg==",
       "dev": true,
       "requires": {
-        "@oclif/command": "^1.5.8",
+        "@oclif/command": "^1.5.13",
         "chalk": "^2.4.1",
         "indent-string": "^3.2.0",
         "lodash.template": "^4.4.0",
@@ -750,9 +750,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "npm-run-path": {
@@ -810,9 +810,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -995,9 +995,9 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-      "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+      "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -1006,9 +1006,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.6.tgz",
-      "integrity": "sha512-8wr3CA/EMybyb6/V8qvTRKiNkPmgUA26uA9XWD6hlA0yFDuqi4r2L0C2B0U2HAYltJamoYJszlkaWM31vrKsHg==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1050,9 +1050,9 @@
       }
     },
     "@types/graphql": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.0.tgz",
-      "integrity": "sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.1.tgz",
+      "integrity": "sha512-81YjgyCz+kYDXkPuk1j4+jCgFjM4DubzrI88tvpWOQp5eILa0A/KvtGAbXONPhD6vRa3neiFb/ES1IDQ82n5Rw==",
       "dev": true
     },
     "@types/handlebars": {
@@ -1479,12 +1479,21 @@
       "dev": true
     },
     "@wry/context": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.2.tgz",
-      "integrity": "sha512-P3IsTHNeQLVjy3Bi9eiyqUwSu4Hai9vpzgueJai8wfibr6JPjyM9KVi2b7uixk1py7aGyOU15cBNvD/l1eZ2eg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
       "dev": true,
       "requires": {
         "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "dev": true,
+      "requires": {
         "tslib": "^1.9.3"
       }
     },
@@ -1511,9 +1520,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -1614,28 +1623,28 @@
       }
     },
     "apollo": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.12.5.tgz",
-      "integrity": "sha512-QHKXZ2Pn+soJ8C2Qjt2cMJyNuXF+NGdX6t2BIi+JPFeAG6mU56Q0PIAYbv5pr2/YvhHJTrIDHvA1QR04BTJqxg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.13.1.tgz",
+      "integrity": "sha512-gTdaVlTe/2KXbjqYOD3+9t7pMIt8aOanxNxG5YJ4gY0sw3151oJAQU39UqK9JRDnGf5XfLq2iD5hTwdFxSPb1g==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "0.3.7",
-        "@oclif/command": "1.5.13",
+        "@oclif/command": "1.5.14",
         "@oclif/config": "1.13.0",
         "@oclif/errors": "1.2.2",
-        "@oclif/plugin-autocomplete": "0.1.0",
-        "@oclif/plugin-help": "2.1.6",
+        "@oclif/plugin-autocomplete": "0.1.1",
+        "@oclif/plugin-help": "2.2.0",
         "@oclif/plugin-not-found": "1.2.2",
         "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.34.4",
-        "apollo-codegen-flow": "0.33.14",
-        "apollo-codegen-scala": "0.34.14",
-        "apollo-codegen-swift": "0.33.14",
-        "apollo-codegen-typescript": "0.34.4",
+        "apollo-codegen-core": "0.34.6",
+        "apollo-codegen-flow": "0.33.16",
+        "apollo-codegen-scala": "0.34.16",
+        "apollo-codegen-swift": "0.33.16",
+        "apollo-codegen-typescript": "0.34.6",
         "apollo-env": "0.5.1",
-        "apollo-graphql": "0.3.1",
-        "apollo-language-server": "1.9.1",
+        "apollo-graphql": "0.3.2",
+        "apollo-language-server": "1.10.1",
         "chalk": "2.4.2",
         "env-ci": "3.2.0",
         "gaze": "1.1.3",
@@ -1655,91 +1664,69 @@
       }
     },
     "apollo-cache": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.1.tgz",
-      "integrity": "sha512-BJ/Mehr3u6XCaHYSmgZ6DM71Fh30OkW6aEr828WjHvs+7i0RUuP51/PM7K6T0jPXtuw7UbArFFPZZsNgXnyyJA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
+      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.3.1",
+        "apollo-utilities": "^1.3.2",
         "tslib": "^1.9.3"
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.1.tgz",
-      "integrity": "sha512-c/WJjh9MTWcdussCTjLKufpPjTx3qOFkBPHIDOOpQ+U0B7K1PczPl9N0LaC4ir3wAWL7s4A0t2EKtoR+6UP92g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz",
+      "integrity": "sha512-AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==",
       "dev": true,
       "requires": {
-        "apollo-cache": "^1.3.1",
-        "apollo-utilities": "^1.3.1",
+        "apollo-cache": "^1.3.2",
+        "apollo-utilities": "^1.3.2",
         "optimism": "^0.9.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "ts-invariant": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.2.tgz",
-          "integrity": "sha512-PTAAn8lJPEdRBJJEs4ig6MVZWfO12yrFzV7YaPslmyhG7+4MA279y4BXT3f72gXeVl0mC1aAWq2rMX4eKTWU/Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "apollo-client": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.1.tgz",
-      "integrity": "sha512-Tb6ZthPZUHlGqeoH1WC8Qg/tLnkk9H5+xj4e5nzOAC6dCOW3pVU9tYXscrWdmZ65UDUg1khvTNjrQgPhdf4aTQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.3.tgz",
+      "integrity": "sha512-DS8pmF5CGiiJ658dG+mDn8pmCMMQIljKJSTeMNHnFuDLV0uAPZoeaAwVFiAmB408Ujqt92oIZ/8yJJAwSIhd4A==",
       "dev": true,
       "requires": {
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.1",
+        "apollo-cache": "1.3.2",
         "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.1",
+        "apollo-utilities": "1.3.2",
         "symbol-observable": "^1.0.2",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
-      },
-      "dependencies": {
-        "ts-invariant": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.2.tgz",
-          "integrity": "sha512-PTAAn8lJPEdRBJJEs4ig6MVZWfO12yrFzV7YaPslmyhG7+4MA279y4BXT3f72gXeVl0mC1aAWq2rMX4eKTWU/Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "apollo-codegen-core": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.34.4.tgz",
-      "integrity": "sha512-pEx78D8BUR6BHC8g1rtPHxecyYG/O7DmNs4DohI3gE0NrYRXvG/ZKVNShUsB+8y3EMVxh6fzyNY++x06ipDuKw==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.34.6.tgz",
+      "integrity": "sha512-wIQOliP6OeP2hwqBk22kej7lfB7IVI7k3Su1Am25ENlSif4bRrvjs3ApeocsOtpu1+ZQVTDFunFA296reu9Oiw==",
       "dev": true,
       "requires": {
         "@babel/generator": "7.4.4",
         "@babel/parser": "^7.1.3",
         "@babel/types": "7.4.4",
         "apollo-env": "0.5.1",
-        "apollo-language-server": "1.9.1",
+        "apollo-language-server": "1.10.1",
         "ast-types": "^0.13.0",
         "common-tags": "^1.5.1",
         "recast": "^0.18.0"
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.33.14",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.14.tgz",
-      "integrity": "sha512-aYb/WJtO/VdOGBiDinacCOYHQJdHEHuCKERsfG9csg7JBP4AF+u/KZsqpBo9wHL/Pf4XnC3XCLd5QoiVi/Dx9Q==",
+      "version": "0.33.16",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.16.tgz",
+      "integrity": "sha512-uXHj21/w4acPxJhzAFr74cxTWGbVIcbPD8RxcTd9hxy0DxaGAm/+WcATiEf+6+5KhXHFqzqWvqChSMuBgugF3g==",
       "dev": true,
       "requires": {
         "@babel/generator": "7.4.4",
         "@babel/types": "7.4.4",
-        "apollo-codegen-core": "0.34.4",
+        "apollo-codegen-core": "0.34.6",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1747,12 +1734,12 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.34.14",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.14.tgz",
-      "integrity": "sha512-/CJhDoye9N4Do5a0ttzES4NY1qUhPPbgvf0TWKU1RIuR5LatiOOMI7p2W0X3e/sijVY/7HgDdZABlqrO9mOITA==",
+      "version": "0.34.16",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.16.tgz",
+      "integrity": "sha512-zHfPni96twjTzK6TeaesSqTlaP6e/OIsOygKPai+44gDIn0lCV7jlEemJLMgL7uwzgdDkNgZOAd1BM6fhmoDpA==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.34.4",
+        "apollo-codegen-core": "0.34.6",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1760,12 +1747,12 @@
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.33.14",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.14.tgz",
-      "integrity": "sha512-iDn2CvQJUo5eJpWgM7NNsyi66Bu1E+J2pfZgd3W5ee/ekRwrec5UnFOmrjtHJlg+gZ8R9gbgQ1WwXPEFsGqBUQ==",
+      "version": "0.33.16",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.16.tgz",
+      "integrity": "sha512-QiRZmGnp2M3eky+17kOYjOHnY0DnFr3axw7kGkoHQRjHN3rHhpEI3ZDQq4FCHqGN8QWi0kdoCLL64cRoBiMPuA==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.34.4",
+        "apollo-codegen-core": "0.34.6",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1773,14 +1760,14 @@
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.34.4.tgz",
-      "integrity": "sha512-MWGrqFcv/JijtI6PxGGMyRhyu65ltWsdfPOXJ8Y9KDDG3ib6wM7z9gaWj0Mr+SI2iDRhhwx6WIM2A9ge4eiqkQ==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.34.6.tgz",
+      "integrity": "sha512-/tmFoQWGtbtouoF6LGzNtHmr793t4OjfWWy0JPl252epZMuH6ix4S4a20IN/WKg/jghviDt4SXgrTEd+G7TN9A==",
       "dev": true,
       "requires": {
         "@babel/generator": "7.4.4",
         "@babel/types": "7.4.4",
-        "apollo-codegen-core": "0.34.4",
+        "apollo-codegen-core": "0.34.6",
         "apollo-env": "0.5.1",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1788,13 +1775,13 @@
       }
     },
     "apollo-datasource": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.4.0.tgz",
-      "integrity": "sha512-6QkgnLYwQrW0qv+yXIf617DojJbGmza2XJXUlgnzrGGhxzfAynzEjaLyYkc8rYS1m82vjrl9EOmLHTcnVkvZAQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.5.0.tgz",
+      "integrity": "sha512-SVXxJyKlWguuDjxkY/WGlC/ykdsTmPxSF0z8FenagcQ91aPURXzXP1ZDz5PbamY+0iiCRubazkxtTQw4GWTFPg==",
       "dev": true,
       "requires": {
         "apollo-server-caching": "0.4.0",
-        "apollo-server-env": "2.3.0"
+        "apollo-server-env": "2.4.0"
       }
     },
     "apollo-env": {
@@ -1809,9 +1796,9 @@
       }
     },
     "apollo-graphql": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.1.tgz",
-      "integrity": "sha512-tbhtzNAAhNI34v4XY9OlZGnH7U0sX4BP1cJrUfSiNzQnZRg1UbQYZ06riHSOHpi5RSndFcA9LDM5C1ZKKOUeBg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.2.tgz",
+      "integrity": "sha512-YbzYGR14GV0023m//EU66vOzZ3i7c04V/SF8Qk+60vf1sOWyKgO6mxZJ4BKhw10qWUayirhSDxq3frYE+qSG0A==",
       "dev": true,
       "requires": {
         "apollo-env": "0.5.1",
@@ -1819,15 +1806,15 @@
       }
     },
     "apollo-language-server": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.9.1.tgz",
-      "integrity": "sha512-7AhmDlK8gbv3UmR+ppICkRBQw64TnzKRIUGl+a6lt4V3sMVkMoBQZACc95lMim7pTUOY2qTesVvjIShjDbXAVw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.10.1.tgz",
+      "integrity": "sha512-JH1d9Pjw1A3Iagg9kyy3U0tttCfRpQpcidpL0K30TYF1OehsBjNW2in328mAmaGoyDMM2UgmiPug3TTUuCul3w==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "0.3.7",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.0",
-        "apollo-datasource": "^0.4.0",
+        "apollo-datasource": "^0.5.0",
         "apollo-env": "0.5.1",
         "apollo-link": "^1.2.3",
         "apollo-link-context": "^1.0.9",
@@ -1850,57 +1837,57 @@
       }
     },
     "apollo-link": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.11.tgz",
-      "integrity": "sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
+      "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
       "dev": true,
       "requires": {
-        "apollo-utilities": "^1.2.1",
-        "ts-invariant": "^0.3.2",
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.18"
+        "zen-observable-ts": "^0.8.19"
       }
     },
     "apollo-link-context": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.17.tgz",
-      "integrity": "sha512-W5UUfHcrrlP5uqJs5X1zbf84AMXhPZGAqX/7AQDgR6wY/7//sMGfJvm36KDkpIeSOElztGtM9z6zdPN1NbT41Q==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.18.tgz",
+      "integrity": "sha512-aG5cbUp1zqOHHQjAJXG7n/izeMQ6LApd/whEF5z6qZp5ATvcyfSNkCfy3KRJMMZZ3iNfVTs6jF+IUA8Zvf+zeg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.11",
+        "apollo-link": "^1.2.12",
         "tslib": "^1.9.3"
       }
     },
     "apollo-link-error": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.10.tgz",
-      "integrity": "sha512-itG5UV7mQqaalmRkuRsF0cUS4zW2ja8XCbxkMZnIEeN24X3yoJi5hpJeAaEkXf0KgYNsR0+rmtCQNruWyxDnZQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.11.tgz",
+      "integrity": "sha512-442DNqn3CNRikDaenMMkoDmCRmkoUx/XyUMlRTZBEFdTw3FYPQLsmDO3hzzC4doY5/BHcn9/jdYh9EeLx4HPsA==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.11",
-        "apollo-link-http-common": "^0.2.13",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
         "tslib": "^1.9.3"
       }
     },
     "apollo-link-http": {
-      "version": "1.5.14",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.14.tgz",
-      "integrity": "sha512-XEoPXmGpxFG3wioovgAlPXIarWaW4oWzt8YzjTYZ87R4R7d1A3wKR/KcvkdMV1m5G7YSAHcNkDLe/8hF2nH6cg==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.15.tgz",
+      "integrity": "sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.11",
-        "apollo-link-http-common": "^0.2.13",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
         "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz",
-      "integrity": "sha512-Uyg1ECQpTTA691Fwx5e6Rc/6CPSu4TB4pQRTGIpwZ4l5JDOQ+812Wvi/e3IInmzOZpwx5YrrOfXrtN8BrsDXoA==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz",
+      "integrity": "sha512-v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==",
       "dev": true,
       "requires": {
-        "apollo-link": "^1.2.11",
-        "ts-invariant": "^0.3.2",
+        "apollo-link": "^1.2.12",
+        "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
       }
     },
@@ -1914,9 +1901,9 @@
       }
     },
     "apollo-server-env": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.3.0.tgz",
-      "integrity": "sha512-WIwlkCM/gir0CkoYWPMTCH8uGCCKB/aM074U1bKayvkFOBVO2VgG5x2kgsfkyF05IMQq2/GOTsKhNY7RnUEhTA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.0.tgz",
+      "integrity": "sha512-7ispR68lv92viFeu5zsRUVGP+oxsVI3WeeBNniM22Cx619maBUwcYTIC3+Y3LpXILhLZCzA1FASZwusgSlyN9w==",
       "dev": true,
       "requires": {
         "node-fetch": "^2.1.2",
@@ -1930,26 +1917,15 @@
       "dev": true
     },
     "apollo-utilities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.1.tgz",
-      "integrity": "sha512-P5cJ75rvhm9hcx9V/xCW0vlHhRd0S2icEcYPoRYNTc5djbynpuO+mQuJ4zMHgjNDpvvDxDfZxXTJ6ZUuJZodiQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
       "dev": true,
       "requires": {
+        "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
-        "lodash.isequal": "^4.5.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "ts-invariant": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.2.tgz",
-          "integrity": "sha512-PTAAn8lJPEdRBJJEs4ig6MVZWfO12yrFzV7YaPslmyhG7+4MA279y4BXT3f72gXeVl0mC1aAWq2rMX4eKTWU/Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "app-root-path": {
@@ -3118,9 +3094,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.3.tgz",
-      "integrity": "sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
       "dev": true
     },
     "core-util-is": {
@@ -3630,9 +3606,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promise-pool": {
@@ -4004,9 +3980,9 @@
       }
     },
     "express-session": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.16.1.tgz",
-      "integrity": "sha512-pWvUL8Tl5jUy1MLH7DhgUlpoKeVPUTe+y6WQD9YhcN0C5qAhsh4a8feVjiUXo3TFhIy191YGZ4tewW9edbl2xQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.16.2.tgz",
+      "integrity": "sha512-oy0sRsdw6n93E9wpCNWKRnSsxYnSDX9Dnr9mhZgqUEEorzcq5nshGYSZ4ZReHFhKQ80WI5iVUUSPW7u3GaKauw==",
       "dev": true,
       "requires": {
         "cookie": "0.3.1",
@@ -4014,7 +3990,7 @@
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-headers": "~1.0.2",
-        "parseurl": "~1.3.2",
+        "parseurl": "~1.3.3",
         "safe-buffer": "5.1.2",
         "uid-safe": "~2.1.5"
       },
@@ -5789,9 +5765,9 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -6312,9 +6288,9 @@
       "dev": true
     },
     "isbinaryfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.0.tgz",
-      "integrity": "sha512-RBtmso6l2mCaEsUvXngMTIjg3oheXo0MgYzzfT6sk44RYggPnm9fT+cQJAmzRnJIxPHXg9FZglqDJGW28dvcqA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.1.tgz",
+      "integrity": "sha512-bvJxbNWm72dy/1+qeBm9F8wUM4siDnlzid7NN5Ib4nQcc0tNIx/YWgEih1ZRHXr8xVbpGk1ccLlA9gOSlyx3gw==",
       "dev": true
     },
     "isemail": {
@@ -6703,12 +6679,6 @@
       "integrity": "sha1-rXvGpOZH15yXLhuA/u968VYmeHY=",
       "dev": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
@@ -6873,9 +6843,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -9608,9 +9578,9 @@
       "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ=="
     },
     "ts-invariant": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
-      "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3"
@@ -10472,9 +10442,9 @@
       "dev": true
     },
     "zen-observable-ts": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz",
-      "integrity": "sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==",
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
+      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@atomist/tree-path": ">=1.0.3"
   },
   "devDependencies": {
-    "@atomist/automation-client": "^1.5.3",
+    "@atomist/automation-client": "1.5.4-master.20190618091503",
     "@atomist/microgrammar": "^1.2.0",
     "@atomist/sdm": "1.5.2-master.20190612102726",
     "@atomist/slack-messages": "^1.1.0",

--- a/test/pack/job/createJob.test.ts
+++ b/test/pack/job/createJob.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommandHandlerRegistration } from "@atomist/sdm";
+import assert = require("power-assert");
+import {
+    createJob,
+    JobTaskType,
+} from "../../../lib/pack/job/createJob";
+
+describe("createJob", () => {
+
+    it("should create job with one task and command name", async () => {
+        const result = await createJob({
+            command: "TestCommand",
+            registration: "@atomist/sdm-test",
+            description: "This is a test command",
+            parameters: {
+                foo: "bar",
+            },
+        }, {
+            context: {
+                name: "@atomist/sdm-test",
+            },
+            graphClient: {
+                mutate: async options => {
+                    const vars = options.variables;
+                    assert.strictEqual(vars.name, "TestCommand");
+                    assert.strictEqual(vars.description, "This is a test command");
+                    assert.strictEqual(vars.owner, "@atomist/sdm-test");
+                    assert.strictEqual(vars.tasks.length, 1);
+                    assert.strictEqual(vars.tasks[0].name, "TestCommand");
+                    assert.strictEqual(vars.tasks[0].data, JSON.stringify({
+                        type: JobTaskType.Command,
+                        parameters: { foo: "bar" },
+                    }));
+
+                    return {
+                        createAtmJob: { id: "123456" },
+                    } as any;
+                },
+            } as any,
+        } as any);
+
+        assert.deepStrictEqual(result, { id: "123456" });
+    });
+
+    it("should create job with one task and command registration", async () => {
+        const result = await createJob({
+            // tslint:disable-next-line:no-object-literal-type-assertion
+            command: { name: "TestCommand" } as CommandHandlerRegistration,
+            registration: "@atomist/sdm-test",
+            description: "This is a test command",
+            parameters: {
+                foo: "bar",
+            },
+        }, {
+            context: {
+                name: "@atomist/sdm-test",
+            },
+            graphClient: {
+                mutate: async options => {
+                    const vars = options.variables;
+                    assert.strictEqual(vars.name, "TestCommand");
+                    assert.strictEqual(vars.description, "This is a test command");
+                    assert.strictEqual(vars.owner, "@atomist/sdm-test");
+                    assert.strictEqual(vars.tasks.length, 1);
+                    assert.strictEqual(vars.tasks[0].name, "TestCommand");
+                    assert.strictEqual(vars.tasks[0].data, JSON.stringify({
+                        type: JobTaskType.Command,
+                        parameters: { foo: "bar" },
+                    }));
+
+                    return {
+                        createAtmJob: { id: "123456" },
+                    } as any;
+                },
+            } as any,
+        } as any);
+
+        assert.deepStrictEqual(result, { id: "123456" });
+    });
+
+    it("should create job with several tasks", async () => {
+        const result = await createJob({
+            command: "TestCommand",
+            registration: "@atomist/sdm-test",
+            description: "This is a test command",
+            parameters: [{
+                color: "blue",
+            }, {
+                color: "red",
+            }, {
+                color: "green",
+            }],
+        }, {
+            context: {
+                name: "@atomist/sdm-test",
+            },
+            graphClient: {
+                mutate: async options => {
+                    const vars = options.variables;
+                    assert.strictEqual(vars.name, "TestCommand");
+                    assert.strictEqual(vars.description, "This is a test command");
+                    assert.strictEqual(vars.owner, "@atomist/sdm-test");
+                    assert.strictEqual(vars.tasks.length, 3);
+                    assert.strictEqual(vars.tasks[0].name, "TestCommand");
+                    assert.strictEqual(vars.tasks[0].data, JSON.stringify({
+                        type: JobTaskType.Command,
+                        parameters: { color: "blue" },
+                    }));
+                    assert.strictEqual(vars.tasks[1].name, "TestCommand");
+                    assert.strictEqual(vars.tasks[1].data, JSON.stringify({
+                        type: JobTaskType.Command,
+                        parameters: { color: "red" },
+                    }));
+                    assert.strictEqual(vars.tasks[2].name, "TestCommand");
+                    assert.strictEqual(vars.tasks[2].data, JSON.stringify({
+                        type: JobTaskType.Command,
+                        parameters: { color: "green" },
+                    }));
+
+                    return {
+                        createAtmJob: { id: "123456" },
+                    } as any;
+                },
+            } as any,
+        } as any);
+
+        assert.deepStrictEqual(result, { id: "123456" });
+    });
+
+});

--- a/test/pack/job/executeTask.test.ts
+++ b/test/pack/job/executeTask.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    EventFired,
+    HandlerContext,
+    HandlerResult,
+    MappedParameter,
+    Parameter,
+    Secret,
+    Secrets,
+    Success,
+} from "@atomist/automation-client";
+import { defaultConfiguration } from "@atomist/automation-client/lib/configuration";
+import {
+    CommandHandler,
+    MappedParameters,
+} from "@atomist/automation-client/lib/decorators";
+import { HandleCommand } from "@atomist/automation-client/lib/HandleCommand";
+import { BuildableAutomationServer } from "@atomist/automation-client/lib/server/BuildableAutomationServer";
+import * as _ from "lodash";
+import * as assert from "power-assert";
+import { JobTaskType } from "../../../lib/pack/job/createJob";
+import { ExecuteTaskListener } from "../../../lib/pack/job/executeTask";
+import {
+    AtmJobTaskState,
+    OnAnyJobTask,
+} from "../../../lib/typings/types";
+
+describe("executeTask", () => {
+
+    afterEach(() => {
+        delete (global as any).__runningAutomationClient;
+    });
+
+    const event: EventFired<OnAnyJobTask.Subscription> = {
+        data: {
+            AtmJobTask: [{
+                name: "TestCommand",
+                state: AtmJobTaskState.created,
+                job: {
+                    data: "{}",
+                },
+                data: JSON.stringify({
+                    type: JobTaskType.Command,
+                }),
+            }],
+        },
+        extensions: {
+            operationName: "ExecuteTask",
+        },
+        secrets: [],
+    };
+
+    it("should fail if command can't be found", async () => {
+        const server = new BuildableAutomationServer(defaultConfiguration());
+        (global as any).__runningAutomationClient = {
+            automationServer: server,
+        };
+
+        const result = await ExecuteTaskListener(
+            event,
+            {
+                graphClient: {
+                    mutate: async options => {
+                        const vars = options.variables;
+                        assert.strictEqual(vars.state.state, AtmJobTaskState.failed);
+                        assert.strictEqual(vars.state.message, "Task command 'TestCommand' could not be found");
+                        return {};
+                    },
+                },
+            } as any, {});
+        assert.strictEqual(result.code, 0);
+    });
+
+    it("should invoke with correctly bound parameters", async () => {
+        const server = new BuildableAutomationServer(defaultConfiguration());
+        (global as any).__runningAutomationClient = {
+            automationServer: server,
+        };
+        server.registerCommandHandler(() => new TestCommand());
+
+        const e = _.merge(
+            {},
+            event,
+            {
+                data: {
+                    AtmJobTask: [{
+                        data: JSON.stringify({
+                            type: JobTaskType.Command,
+                            parameters: {
+                                param: "bar",
+                                owner: "atomist",
+                                token: "123456",
+                            },
+                        }),
+                    }],
+                },
+            });
+
+        const result = await ExecuteTaskListener(
+            e,
+            {
+                graphClient: {
+                    mutate: async options => {
+                        const vars = options.variables;
+                        assert.strictEqual(vars.state.state, AtmJobTaskState.success);
+                        return {};
+                    },
+                },
+            } as any, {});
+        assert.strictEqual(result.code, 0);
+    });
+
+});
+
+@CommandHandler("Some test command")
+class TestCommand implements HandleCommand {
+
+    @Parameter()
+    public param: string;
+
+    @Secret(Secrets.UserToken)
+    public token: string;
+
+    @MappedParameter(MappedParameters.GitHubOwner)
+    public owner: string;
+
+    public async handle(ctx: HandlerContext): Promise<HandlerResult> {
+        assert.strictEqual(this.param, "bar");
+        assert.strictEqual(this.owner, "atomist");
+        assert.strictEqual(this.token, "123456");
+        return Success;
+    }
+}


### PR DESCRIPTION
This adds support for scheduling `CommandRegistration` types like `CommandHandlerRegistration` or `CodeTransformRegistration` as a series of tasks inside a job.

Tasks of a job spread across all instances of the SDM and therefore scale much better compared to execute a large number of commands inside one SDM.  