### PR TITLE
Add id's to repo, branch and org for fingerprinting

### DIFF
--- a/lib/graphql/fragment/CoreRepoFieldsAndChannels.graphql
+++ b/lib/graphql/fragment/CoreRepoFieldsAndChannels.graphql
@@ -1,8 +1,10 @@
 fragment CoreRepoFieldsAndChannels on Repo {
+  id
   url
   owner
   name
   org {
+    id
     owner
     ownerType
     provider {
@@ -11,6 +13,10 @@ fragment CoreRepoFieldsAndChannels on Repo {
       apiUrl
       url
     }
+  }
+  branches {
+    id
+    name
   }
   channels {
     team {


### PR DESCRIPTION
We'd like this so that the fingerprinting code doesn't need to look up those ids using ad-hoc queries, but instead be able to grab them directly from the subscription event