### PR TITLE
Introduce `createGoals` on SDM

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,7 @@ export {
     SdmVersionForCommit,
 } from "./lib/typings/types";
 import * as github from "./lib/util/github/ghub";
+
 export {
     gitHubGoalStatus,
     githubGoalStatusSupport,
@@ -206,4 +207,9 @@ export {
     Configurer,
     GoalData,
     GoalStructure,
+    CreateGoals,
+    GoalConfigurer,
+    GoalCreator,
+    ConfigurationPreProcessor,
+    AllGoals,
 } from "./lib/machine/configure";


### PR DESCRIPTION
This PR adds support to use `createGoals` function on the SDM instance inside `configure`:

```typescript
export interface SpringGoals extends AllGoals {
    autofix: Autofix;
    version: Version;
    codeInspection: AutoCodeInspection;
    pushImpact: PushImpact;
    build: Build;
    dockerBuild: DockerBuild;
}

export const configuration = configure<SpringGoals>(async sdm => {

    const goals = await sdm.createGoals(SpringGoalCreator, SpringGoalConfigurer);

    return {
        check: {
            test: IsMaven,
            goals: [
                [goals.cancel, goals.autofix],
                [goals.codeInspection, goals.version, goals.fingerprint, goals.pushImpact],
            ],
        },
    ...
    };
});
```

This is entirely optional to use and backwards compatible. 