### PR TITLE
Apply policy for TypeScript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.5.3"
+    "typescript": "3.5.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Apply policy `typescript-version::typescript-version`:

**New TypeScript Version Policy**
Policy version for TypeScript is `3.5.3`.
Project *atomist/sdm-core/master* is currently using version `^3.5.3`.

_TypeScript Version_
```TypeScript version (3.5.3)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=7a77ba0d291de4dc2ec4893c0b08287c9968f9fa36c9f9987c5bb676bf5c9189]</code>
</details>