### PR TITLE
Use git to tag

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -63,14 +63,20 @@ export {
     EphemeralLocalArtifactStore,
 } from "./lib/internal/artifact/local/EphemeralLocalArtifactStore";
 export {
+    createGitTag,
+    CreateGitTagOptions,
     createTagForStatus,
     executeTag,
+    ExecuteTagOptions,
 } from "./lib/internal/delivery/build/executeTag";
 export {
     ProjectIdentifier,
 } from "./lib/internal/delivery/build/local/projectIdentifier";
 export {
     executeVersioner,
+    getGoalVersion,
+    GetGoalVersionArguments,
+    goalInvocationVersion,
     ProjectVersioner,
     readSdmVersion,
 } from "./lib/internal/delivery/build/local/projectVersioner";
@@ -211,6 +217,7 @@ export {
     GoalConfigurer,
     GoalCreator,
     ConfigurationPreProcessor,
+    ConfigureMachineOptions,
     AllGoals,
     DeliveryGoals,
 } from "./lib/machine/configure";

--- a/lib/goal/common/Tag.ts
+++ b/lib/goal/common/Tag.ts
@@ -16,21 +16,34 @@
 
 import {
     DefaultGoalNameGenerator,
+    ExecuteGoal,
     FulfillableGoal,
     FulfillableGoalDetails,
     getGoalDefinitionFrom,
     Goal,
+    SoftwareDeliveryMachine,
 } from "@atomist/sdm";
 import { executeTag } from "../../internal/delivery/build/executeTag";
 
 /**
- * Goal that performs project tagging on GitHub
+ * Properties to customize [[Tag]] goal.
+ */
+export interface TagRegistration {
+    /** Set fulfillment goal executor. */
+    goalExecutor?: ExecuteGoal;
+    /** Name for fulfillment. */
+    name?: string;
+}
+
+/**
+ * Goal that performs project tagging using Git.  If no fulfillment is
+ * added to the goal, one is added during registration that tags using
+ * the goal set pre-release version as created by the [[Version]]
+ * goal.
  */
 export class Tag extends FulfillableGoal {
 
-    constructor(goalDetailsOrUniqueName: FulfillableGoalDetails | string = DefaultGoalNameGenerator.generateName("tag"),
-                ...dependsOn: Goal[]) {
-
+    constructor(goalDetailsOrUniqueName: FulfillableGoalDetails | string = DefaultGoalNameGenerator.generateName("tag"), ...dependsOn: Goal[]) {
         super({
             workingDescription: "Tagging",
             completedDescription: "Tagged",
@@ -38,10 +51,33 @@ export class Tag extends FulfillableGoal {
             ...getGoalDefinitionFrom(goalDetailsOrUniqueName, DefaultGoalNameGenerator.generateName("tag")),
             displayName: "tag",
         }, ...dependsOn);
+    }
 
-        this.addFulfillment({
-            name: DefaultGoalNameGenerator.generateName("tag"),
-            goalExecutor: executeTag(),
+    /**
+     * Called by the SDM on initialization.  This function calls
+     * `super.register` and adds a startup listener to the SDM.
+     *
+     * The startup listener registers a default goal fulfillment that
+     * calles [[executeTag]] with no arguments.
+     */
+    public register(sdm: SoftwareDeliveryMachine): void {
+        super.register(sdm);
+
+        sdm.addStartupListener(async () => {
+            if (this.fulfillments.length === 0 && this.callbacks.length === 0) {
+                this.with();
+            }
         });
     }
+
+    /**
+     * Add fulfillment to this goal.
+     */
+    public with(registration: TagRegistration = {}): this {
+        const name = registration.name || DefaultGoalNameGenerator.generateName((registration.goalExecutor) ? "custom-tag" : "prerelease-tag");
+        const goalExecutor = registration.goalExecutor || executeTag();
+        super.addFulfillment({ name, goalExecutor });
+        return this;
+    }
+
 }

--- a/lib/goal/container/util.ts
+++ b/lib/goal/container/util.ts
@@ -21,7 +21,7 @@ import {
     SdmGoalEvent,
 } from "@atomist/sdm";
 import * as fs from "fs-extra";
-import { readSdmVersion } from "../../internal/delivery/build/local/projectVersioner";
+import { getGoalVersion } from "../../internal/delivery/build/local/projectVersioner";
 import { K8sNamespaceFile } from "../../pack/k8s/KubernetesGoalScheduler";
 
 /**
@@ -43,14 +43,14 @@ export function runningInK8s(): boolean {
  * @return SDM goal environment variables
  */
 export async function containerEnvVars(goalEvent: SdmGoalEvent, ctx: SdmContext): Promise<Array<{ name: string, value: string }>> {
-    const version = await readSdmVersion(
-        goalEvent.repo.owner,
-        goalEvent.repo.name,
-        goalEvent.repo.providerId,
-        goalEvent.sha,
-        goalEvent.branch,
-        ctx.context,
-    );
+    const version = await getGoalVersion({
+        owner: goalEvent.repo.owner,
+        repo: goalEvent.repo.name,
+        providerId: goalEvent.repo.providerId,
+        sha: goalEvent.sha,
+        branch: goalEvent.branch,
+        context: ctx.context,
+    });
     return [{
         name: "ATOMIST_SLUG",
         value: `${goalEvent.repo.owner}/${goalEvent.repo.name}`,

--- a/lib/internal/delivery/build/executeTag.ts
+++ b/lib/internal/delivery/build/executeTag.ts
@@ -16,36 +16,147 @@
 
 import {
     GitHubRepoRef,
+    GitProject,
+    logger,
     ProjectOperationCredentials,
     RemoteRepoRef,
-    Success,
 } from "@atomist/automation-client";
 import {
     ExecuteGoal,
     ExecuteGoalResult,
     GoalInvocation,
+    LoggingProgressLog,
+    ProgressLog,
+    spawnLog,
 } from "@atomist/sdm";
 import {
     createTag,
     createTagReference,
     Tag,
 } from "../../../util/github/ghub";
-import { readSdmVersion } from "./local/projectVersioner";
+import { goalInvocationVersion } from "./local/projectVersioner";
 
-export function executeTag(): ExecuteGoal {
+/**
+ * Options for creating a tag.  If neither `name` or `release` are
+ * truthy, a prerelease, i.e., timestamped, version tag is created.
+ * If both `name` and `release` are truthy, `name` takes precedence.
+ */
+export interface ExecuteTagOptions {
+    /** Name of tag to create. */
+    name?: string;
+    /**
+     * If `true`, create a release semantic version tag, not a
+     * prerelease version tag.
+     */
+    release?: boolean;
+    /**
+     * Semantic version build metadata to append to tag, e.g.,
+     * "sdm.BUILD_NUMBER".
+     */
+    build?: string;
+}
+
+/**
+ * Create and return an execute goal object that creates a Git tag,
+ * suitable for use with the [[Tag]] goal.
+ *
+ * @param opts Options that determine the tag created
+ * @return Success if successful, Failure otherwise
+ */
+export function executeTag(opts: ExecuteTagOptions = {}): ExecuteGoal {
     return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
-        const { configuration, goalEvent, credentials, id, context } = goalInvocation;
+        const { configuration, goalEvent, credentials, id, context, progressLog } = goalInvocation;
 
-        return configuration.sdm.projectLoader.doWithProject({ credentials, id, context, readOnly: true }, async p => {
-            const version = await readSdmVersion(goalEvent.repo.owner, goalEvent.repo.name,
-                goalEvent.repo.providerId, goalEvent.sha, id.branch, context);
-            await createTagForStatus(id, goalEvent.sha, goalEvent.push.after.message, version, credentials);
-
-            return Success;
+        return configuration.sdm.projectLoader.doWithProject({ credentials, id, context, readOnly: false }, async project => {
+            try {
+                let tag: string;
+                let message: string = (goalEvent.push.after && goalEvent.push.after.message) ? goalEvent.push.after.message : undefined;
+                if (opts.name) {
+                    tag = opts.name;
+                    message = message || `Tag ${opts.name}`;
+                } else {
+                    const version = await goalInvocationVersion(goalInvocation);
+                    if (opts.release) {
+                        tag = version.replace(/[-+].*/, "");
+                        message = message || `Release ${tag}`;
+                    } else {
+                        tag = version;
+                        message = message || `Prerelease ${tag}`;
+                    }
+                }
+                if (opts.build) {
+                    tag += "+" + opts.build;
+                }
+                await createGitTag({ project, tag, message, log: progressLog });
+                return { code: 0, message: `Created tag '${tag}' for ${goalEvent.repo.owner}/${goalEvent.repo.name}` };
+            } catch (e) {
+                const message = `Failed to create tag for ${goalEvent.repo.owner}/${goalEvent.repo.name}: ${e.message}`;
+                logger.error(message);
+                progressLog.write(message);
+                return { code: 1, message };
+            }
         });
     };
 }
 
+/** [[createTag]] function arguments. */
+export interface CreateGitTagOptions {
+    /** Git repository project to operate on. */
+    project: GitProject;
+    /** Name of tag to create and push. */
+    tag: string;
+    /** Optional message to associate with Git tag. */
+    message?: string;
+    /** Optional progress log to write updates to. */
+    log?: ProgressLog;
+}
+
+/**
+ * Create and push a Git tag with optional message.
+ *
+ * @param opts Options for creating a Git tag.
+ */
+export async function createGitTag(opts: CreateGitTagOptions): Promise<void> {
+    if (!opts.tag) {
+        throw new Error("You must provide a valid Git tag");
+    }
+    if (!opts.project) {
+        throw new Error("You must provide a Git project");
+    }
+    if (!opts.log) {
+        opts.log = new LoggingProgressLog("logger");
+    }
+    const remote = opts.project.remote || "origin";
+    try {
+        const spawnOpts = { cwd: opts.project.baseDir, log: opts.log };
+        const tagArgs = ["tag", opts.tag];
+        if (opts.message) {
+            tagArgs.splice(1, 0, "-m", opts.message);
+        }
+        const tagResult = await spawnLog("git", tagArgs, spawnOpts);
+        if (tagResult.code) {
+            throw new Error(`git tag failed: ${tagResult.message}`);
+        }
+        const pushResult = await spawnLog("git", ["push", remote, opts.tag], spawnOpts);
+        if (pushResult.code) {
+            throw new Error(`git push failed: ${pushResult.message}`);
+        }
+    } catch (e) {
+        e.message = `Failed to create and push git tag '${opts.tag}': ${e.message}`;
+        throw e;
+    }
+}
+
+/**
+ * Create a GitHub tag using the GitHub API.
+ *
+ * @param id GitHub remote repository reference
+ * @param sha Commit SHA to tag
+ * @param message Tag message
+ * @param version Name of tag
+ * @param credentials GitHub token object
+ * @deprecated use createGitTag
+ */
 export async function createTagForStatus(id: RemoteRepoRef,
                                          sha: string,
                                          message: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -639,7 +639,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
       "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
         "run-parallel": "^1.1.9"
@@ -648,14 +647,12 @@
     "@nodelib/fs.stat": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
-      "dev": true
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
       "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
@@ -1018,18 +1015,18 @@
       "dev": true
     },
     "@octokit/endpoint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.4.0.tgz",
-      "integrity": "sha512-DWTNgEKg5KXzvNjKTzcFTnkZiL7te6pQxxumvxPjyjDpcY5V3xzywnNu1WVqySY3Ct1flF/kAoyDdZos6acq3Q==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.4.1.tgz",
+      "integrity": "sha512-iwn46orWg3F4iqIzAVRfbzhnROyx7BQ7zJE0B7SEeaMIBvk3qmWtswtRk14QkMNUuNiCHQ6mAM00VJxWqrdM1g==",
       "requires": {
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^4.0.0"
       }
     },
     "@octokit/request": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
-      "integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.2.1.tgz",
+      "integrity": "sha512-onjQo4QKyiMAqLM6j3eH8vWw1LEfNCpoZUl6a+TrZVJM1wysBC8F0GhK9K/Vc9UsScSmVs2bstOVD34xpQ2wqQ==",
       "requires": {
         "@octokit/endpoint": "^5.1.0",
         "@octokit/request-error": "^1.0.1",
@@ -1050,11 +1047,11 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.33.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.33.0.tgz",
-      "integrity": "sha512-t4jMR+odsfooQwmHiREoTQixVTX2DfdbSaO+lKrW9R5XBuk0DW+5T/JdfwtxAGUAHgvDDpWY/NVVDfEPTzxD6g==",
+      "version": "16.33.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.33.1.tgz",
+      "integrity": "sha512-lOQ+fJZwkeJ/1PRTdnY1uNja01aKOMioRhQfZtei64gZMXIX3EAfF4koMQMvoLFwsnVBu3ifj1JW1WAAKdXcnA==",
       "requires": {
-        "@octokit/request": "^5.0.0",
+        "@octokit/request": "^5.2.0",
         "@octokit/request-error": "^1.0.2",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^2.0.0",
@@ -1167,7 +1164,8 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/express": {
       "version": "4.17.1",
@@ -1205,7 +1203,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.0.tgz",
       "integrity": "sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1214,6 +1211,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/minimatch": "*",
@@ -1267,10 +1265,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.142",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.142.tgz",
-      "integrity": "sha512-ZhNS7c4D4WQ49Dr1FftQj7SwngRswOnPfxktmqSy5BettRCuum2q784jRwNTYfxH00r8+fEgRz6Da8j5DHNd1Q==",
-      "dev": true
+      "version": "4.14.144",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
+      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -1281,7 +1278,8 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -1290,9 +1288,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
+      "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A=="
     },
     "@types/node-statsd": {
       "version": "0.1.2",
@@ -2406,7 +2404,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -3866,7 +3863,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
       "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3896,7 +3892,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
       "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.0"
       }
@@ -3934,7 +3929,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -4204,7 +4198,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
       "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -4926,8 +4919,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -4939,7 +4931,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -4988,8 +4979,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-object": {
       "version": "1.0.1",
@@ -5740,8 +5730,7 @@
     "merge2": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
-      "dev": true
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
     },
     "methods": {
       "version": "1.1.2",
@@ -5762,7 +5751,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
       "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
@@ -6743,8 +6731,7 @@
     "picomatch": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
-      "dev": true
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
     },
     "pidtree": {
       "version": "0.3.0",
@@ -7239,8 +7226,7 @@
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
       "version": "3.0.0",
@@ -7263,8 +7249,7 @@
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "rxjs": {
       "version": "6.5.3",
@@ -7945,7 +7930,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -8163,9 +8147,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -25,19 +25,21 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.10.2",
-    "@octokit/rest": "^16.28.3",
+    "@octokit/rest": "^16.33.1",
     "@types/flat": "0.0.28",
-    "@types/glob": "^7.1.1",
+    "@types/fs-extra": "^8.0.0",
+    "@types/lodash": "^4.14.144",
+    "@types/node": "^12.11.1",
     "@types/proper-lockfile": "^4.1.0",
     "@types/request": "^2.48.1",
     "@types/retry": "^0.12.0",
     "app-root-path": "^2.2.1",
     "axios": "^0.19.0",
     "chalk": "^2.4.2",
+    "fast-glob": "^3.1.0",
     "fast-json-stable-stringify": "^2.0.0",
     "flat": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "glob": "^7.1.4",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
@@ -61,9 +63,7 @@
     "@atomist/sdm": "1.8.0-master.20191009103804",
     "@atomist/slack-messages": " ^1.1.1",
     "@atomist/tree-path": "^1.0.3",
-    "@types/lodash": "^4.14.138",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.4",
     "@types/power-assert": "^1.5.0",
     "@types/rimraf": "^2.0.2",
     "axios-mock-adapter": "^1.17.0",
@@ -77,7 +77,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.19.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.6.3"
+    "typescript": "^3.6.4"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Use Git CLI to tag rather than GitHub API.  Support using Tag goal to
tag for release versions and arbitrary tags in addition to prerelease
versions while maintaining current behavior as default.

Add convenience function for getting goal invocation version.

Replace glob with fast-glob and clean up dependencies.  Update
TypeScript.  Add missing ConfigureMachineOptions to index.ts exports.