### PR TITLE
Do not close progress log if goal not complete

### DIFF
--- a/lib/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
+++ b/lib/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
@@ -172,6 +172,7 @@ export class FulfillGoalOnRequested implements HandleEvent<OnAnyRequestedSdmGoal
                     SdmGoalState.skipped,
                     SdmGoalState.stopped,
                     SdmGoalState.success,
+                    SdmGoalState.waiting_for_approval,
                 ];
                 if (!result || !result.state || terminatingStates.includes(result.state)) {
                     await reportEndAndClose(result, start, progressLog);

--- a/lib/pack/k8s/KubernetesGoalScheduler.ts
+++ b/lib/pack/k8s/KubernetesGoalScheduler.ts
@@ -610,7 +610,7 @@ export async function deletePods(job: { name: string, namespace: string }): Prom
                     // Probably ok because pod might be gone already
                     logger.debug(
                         `Failed to delete k8s pod '${pod.metadata.namespace}:${pod.metadata.name}': ${
-                            prettyPrintError(e)}`);
+                        prettyPrintError(e)}`);
                 }
             }
         }


### PR DESCRIPTION
When executing the FulfillGoalOnRequested event handler, only close
the progress log if the goal state is not set or set to a status
indicating completion.

Closes #206