### PR TITLE
Add placeholder replacement in cache classifier

### DIFF
--- a/lib/goal/cache/FileSystemGoalCacheArchiveStore.ts
+++ b/lib/goal/cache/FileSystemGoalCacheArchiveStore.ts
@@ -28,9 +28,11 @@ import { GoalCacheArchiveStore } from "./CompressingGoalCache";
  * Goal archive store that stores the compressed archives into the SDM cache directory.
  */
 export class FileSystemGoalCacheArchiveStore implements GoalCacheArchiveStore {
+    private static readonly archiveName: string = "cache.tar.gz";
+
     public async store(gi: GoalInvocation, classifier: string, archivePath: string): Promise<void> {
         const cacheDir = await FileSystemGoalCacheArchiveStore.getCacheDirectory(gi, classifier);
-        const archiveName = FileSystemGoalCacheArchiveStore.getArchiveName(gi);
+        const archiveName = FileSystemGoalCacheArchiveStore.archiveName;
         const archiveFileName = path.join(cacheDir, archiveName);
         await spawnLog("mv", [archivePath, archiveFileName], {
             log: gi.progressLog,
@@ -39,7 +41,7 @@ export class FileSystemGoalCacheArchiveStore implements GoalCacheArchiveStore {
 
     public async delete(gi: GoalInvocation, classifier: string): Promise<void> {
         const cacheDir = await FileSystemGoalCacheArchiveStore.getCacheDirectory(gi, classifier);
-        const archiveName = FileSystemGoalCacheArchiveStore.getArchiveName(gi);
+        const archiveName = FileSystemGoalCacheArchiveStore.archiveName;
         const archiveFileName = path.join(cacheDir, archiveName);
         await spawnLog("rm", ["-f", archiveFileName], {
             log: gi.progressLog,
@@ -48,7 +50,7 @@ export class FileSystemGoalCacheArchiveStore implements GoalCacheArchiveStore {
 
     public async retrieve(gi: GoalInvocation, classifier: string, targetArchivePath: string): Promise<void> {
         const cacheDir = await FileSystemGoalCacheArchiveStore.getCacheDirectory(gi, classifier);
-        const archiveName = FileSystemGoalCacheArchiveStore.getArchiveName(gi);
+        const archiveName = FileSystemGoalCacheArchiveStore.archiveName;
         const archiveFileName = path.join(cacheDir, archiveName);
         await spawnLog("cp", [archiveFileName, targetArchivePath], {
             log: gi.progressLog,
@@ -62,9 +64,5 @@ export class FileSystemGoalCacheArchiveStore implements GoalCacheArchiveStore {
         const cacheDir = path.join(sdmCacheDir, classifier);
         await fs.mkdirs(cacheDir);
         return cacheDir;
-    }
-
-    private static getArchiveName(gi: GoalInvocation): string {
-        return `${gi.goalEvent.sha}-cache.tar.gz`;
     }
 }

--- a/lib/goal/container/execute.ts
+++ b/lib/goal/container/execute.ts
@@ -26,7 +26,7 @@ import * as fs from "fs-extra";
 import * as _ from "lodash";
 import * as os from "os";
 import * as path from "path";
-import { resolvePlaceholder } from "../../machine/yaml/mapGoals";
+import { resolvePlaceholder } from "../../machine/yaml/resolvePlaceholder";
 import {
     CacheEntry,
     cachePut,

--- a/lib/machine/yaml/mapGoals.ts
+++ b/lib/machine/yaml/mapGoals.ts
@@ -38,7 +38,6 @@ import {
 import * as changeCase from "change-case";
 import * as yaml from "js-yaml";
 import * as _ from "lodash";
-import * as os from "os";
 import {
     CacheEntry,
     cachePut,
@@ -54,13 +53,13 @@ import {
     GoalContainerSpec,
 } from "../../goal/container/container";
 import { execute } from "../../goal/container/execute";
-import { getGoalVersion } from "../../internal/delivery/build/local/projectVersioner";
 import { toArray } from "../../util/misc/array";
 import { DeliveryGoals } from "../configure";
 import {
     mapTests,
     PushTestMaker,
 } from "./mapPushTests";
+import { resolvePlaceholder } from "./resolvePlaceholder";
 import { camelCase } from "./util";
 
 // tslint:disable:max-file-line-count
@@ -475,54 +474,4 @@ async function resolvePlaceholderContainerSpecCallback(r: ContainerRegistration,
                                                        ctx: RepoContext): Promise<GoalContainerSpec> {
     await resolvePlaceholders(r as any, value => resolvePlaceholder(value, e, ctx, (r as any).parameters));
     return r;
-}
-
-const PlaceholderExpression = /\$\{([.a-zA-Z_-]+)([.:0-9a-zA-Z-_ \" ]+)*\}/g;
-
-export async function resolvePlaceholder(value: string,
-                                         goal: SdmGoalEvent,
-                                         ctx: Pick<RepoContext, "configuration" | "context">,
-                                         parameters: Record<string, any>,
-                                         raiseError: boolean = true): Promise<string> {
-    if (!PlaceholderExpression.test(value)) {
-        return value;
-    }
-    PlaceholderExpression.lastIndex = 0;
-    let currentValue = value;
-    let result: RegExpExecArray;
-    // tslint:disable-next-line:no-conditional-assignment
-    while (result = PlaceholderExpression.exec(currentValue)) {
-        const fm = result[0];
-        let envValue = _.get(goal, result[1]) ||
-            _.get(ctx.configuration, result[1]) ||
-            _.get(ctx.configuration, camelCase(result[1])) ||
-            _.get({ parameters }, result[1]) ||
-            _.get({ parameters }, camelCase(result[1]));
-        if (result[1] === "home") {
-            envValue = os.userInfo().homedir;
-        } else if (result[1] === "push.after.version" && !!goal) {
-            envValue = await getGoalVersion({
-                context: ctx.context,
-                owner: goal.repo.owner,
-                repo: goal.repo.name,
-                providerId: goal.repo.providerId,
-                branch: goal.branch,
-                sha: goal.sha,
-            });
-        }
-        const defaultValue = result[2] ? result[2].trim().slice(1) : undefined;
-
-        if (typeof envValue === "string") {
-            currentValue = currentValue.split(fm).join(envValue);
-            PlaceholderExpression.lastIndex = 0;
-        } else if (typeof envValue === "object" && value === fm) {
-            return envValue;
-        } else if (defaultValue) {
-            currentValue = currentValue.split(fm).join(defaultValue);
-            PlaceholderExpression.lastIndex = 0;
-        } else if (raiseError) {
-            throw new Error(`Placeholder '${result[1]}' can't be resolved`);
-        }
-    }
-    return currentValue;
 }

--- a/lib/machine/yaml/resolvePlaceholder.ts
+++ b/lib/machine/yaml/resolvePlaceholder.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    RepoContext,
+    SdmGoalEvent,
+} from "@atomist/sdm";
+import * as _ from "lodash";
+import * as os from "os";
+import { getGoalVersion } from "../../internal/delivery/build/local/projectVersioner";
+import { camelCase } from "./util";
+
+const PlaceholderExpression = /\$\{([.a-zA-Z_-]+)([.:0-9a-zA-Z-_ \" ]+)*\}/g;
+
+export async function resolvePlaceholder(value: string,
+                                         goal: SdmGoalEvent,
+                                         ctx: Pick<RepoContext, "configuration" | "context">,
+                                         parameters: Record<string, any>,
+                                         raiseError: boolean = true): Promise<string> {
+    if (!PlaceholderExpression.test(value)) {
+        return value;
+    }
+    PlaceholderExpression.lastIndex = 0;
+    let currentValue = value;
+    let result: RegExpExecArray;
+    // tslint:disable-next-line:no-conditional-assignment
+    while (result = PlaceholderExpression.exec(currentValue)) {
+        const fm = result[0];
+        let envValue = _.get(goal, result[1]) ||
+            _.get(ctx.configuration, result[1]) ||
+            _.get(ctx.configuration, camelCase(result[1])) ||
+            _.get({ parameters }, result[1]) ||
+            _.get({ parameters }, camelCase(result[1]));
+        if (result[1] === "home") {
+            envValue = os.userInfo().homedir;
+        } else if (result[1] === "push.after.version" && !!goal) {
+            envValue = await getGoalVersion({
+                context: ctx.context,
+                owner: goal.repo.owner,
+                repo: goal.repo.name,
+                providerId: goal.repo.providerId,
+                branch: goal.branch,
+                sha: goal.sha,
+            });
+        }
+        const defaultValue = result[2] ? result[2].trim().slice(1) : undefined;
+
+        if (typeof envValue === "string") {
+            currentValue = currentValue.split(fm).join(envValue);
+            PlaceholderExpression.lastIndex = 0;
+        } else if (typeof envValue === "object" && value === fm) {
+            return envValue;
+        } else if (defaultValue) {
+            currentValue = currentValue.split(fm).join(defaultValue);
+            PlaceholderExpression.lastIndex = 0;
+        } else if (raiseError) {
+            throw new Error(`Placeholder '${result[1]}' can't be resolved`);
+        }
+    }
+    return currentValue;
+}

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typedoc": "npm run doc"
   },
   "engines": {
-    "node": ">=8.1.0",
+    "node": ">=8.2.0",
     "npm": ">=5.0.0"
   }
 }

--- a/test/goal/cache/CompressingGoalCache.test.ts
+++ b/test/goal/cache/CompressingGoalCache.test.ts
@@ -36,268 +36,430 @@ import * as assert from "power-assert";
 import * as rimraf from "rimraf";
 import { promisify } from "util";
 import {
+    CompressingGoalCache,
+    resolveClassifier,
+    sanitizeClassifier,
+} from "../../../lib/goal/cache/CompressingGoalCache";
+import {
     cachePut,
     cacheRemove,
     cacheRestore,
-    CompressingGoalCache,
     GoalCacheOptions,
-} from "../../../index";
+} from "../../../lib/goal/cache/goalCaching";
 
-describe("CompressingGoalCache", () => {
+describe("goal/cache/CompressingGoalCache", () => {
 
-    const testDirPrefix = path.join(os.tmpdir(), "sdm-core-test-");
+    describe("sanitizeClassifier", () => {
 
-    function testDir(): string {
-        return testDirPrefix + guid();
-    }
+        it("should do nothing successfully", () => {
+            ["", "simple", "foo.bar", "foo..bar"].forEach(c => {
+                const s = sanitizeClassifier(c);
+                assert(s === c);
+            });
+        });
 
-    async function createTempProject(fakePushId: RepoRef): Promise<LocalProject> {
-        const projectDir = testDir();
-        await fs.ensureDir(projectDir);
-        return NodeFsLocalProject.fromExistingDirectory(fakePushId, projectDir);
-    }
+        it("should unhide paths", () => {
+            [
+                { c: ".foo", e: "foo" },
+                { c: "..foo", e: "foo" },
+                { c: "._foo", e: "_foo" },
+                { c: "./.", e: "_." },
+                { c: "././.", e: "_._." },
+                { c: "./.././", e: "_.._._" },
+                { c: "..", e: "" },
+                { c: "../../..", e: "_.._.." },
+                { c: "../../../", e: "_.._.._" },
+                { c: "../../../foo", e: "_.._.._foo" },
+            ].forEach(ce => {
+                const s = sanitizeClassifier(ce.c);
+                assert(s === ce.e);
+                const b = ce.c.replace(/\//g, "\\");
+                const t = sanitizeClassifier(b);
+                assert(t === ce.e);
+            });
+        });
 
-    const ErrorProjectListenerRegistration: GoalProjectListenerRegistration = {
-        name: "Error",
-        listener: async () => { throw Error("Cache miss"); },
-        pushTest: AnyPush,
-    };
+        it("should replace invalid characters", () => {
+            [
+                { c: "/", e: "_" },
+                { c: "///", e: "___" },
+                { c: "/foo", e: "_foo" },
+                { c: "///foo", e: "___foo" },
+                { c: "//foo//", e: "__foo__" },
+                { c: "/../../../foo", e: "_.._.._.._foo" },
+                { c: "_foo", e: "_foo" },
+                { c: "__foo", e: "__foo" },
+                { c: "foo.", e: "foo." },
+                { c: "foo..", e: "foo.." },
+                { c: "foo/", e: "foo_" },
+                { c: "foo////", e: "foo____" },
+                { c: "foo/..", e: "foo_.." },
+                { c: "foo/.././..", e: "foo_.._._.." },
+                { c: "foo/././././", e: "foo_._._._._" },
+                { c: "foo/../../../..", e: "foo_.._.._.._.." },
+                { c: "foo/../../../../", e: "foo_.._.._.._.._" },
+                { c: "foo/./bar", e: "foo_._bar" },
+                { c: "foo/././bar", e: "foo_._._bar" },
+                { c: "foo/././././bar", e: "foo_._._._._bar" },
+                { c: "foo/../bar", e: "foo_.._bar" },
+                { c: "foo/../../bar", e: "foo_.._.._bar" },
+                { c: "foo/../../../../bar", e: "foo_.._.._.._.._bar" },
+                { c: "foo/./.././../bar", e: "foo_._.._._.._bar" },
+                { c: "foo/.././.././bar", e: "foo_.._._.._._bar" },
+                { c: "foo/..///.//../bar", e: "foo_..___.__.._bar" },
+                { c: "foo/.././/.././bar/../././//..//./baz", e: "foo_.._.__.._._bar_.._._.___..__._baz" },
+                { c: "foo/.../bar", e: "foo_..._bar" },
+                { c: "foo/..../bar", e: "foo_...._bar" },
+                { c: "foo/.bar", e: "foo_.bar" },
+                { c: "foo/..bar", e: "foo_..bar" },
+                { c: "foo/...bar", e: "foo_...bar" },
+                { c: "foo/.bar/.baz", e: "foo_.bar_.baz" },
+                { c: "foo/..bar/..baz", e: "foo_..bar_..baz" },
+                { c: "foo/.../bar/.../baz", e: "foo_..._bar_..._baz" },
+                { c: "foo/....bar.baz", e: "foo_....bar.baz" },
+                { c: "foo/.../.bar.baz", e: "foo_..._.bar.baz" },
+                { c: "foo/....bar.baz/.qux.", e: "foo_....bar.baz_.qux." },
+            ].forEach(ce => {
+                const s = sanitizeClassifier(ce.c);
+                assert(s === ce.e);
+                const b = ce.c.replace(/\//g, "\\");
+                const t = sanitizeClassifier(b);
+                assert(t === ce.e);
+            });
+        });
 
-    const rm = promisify(rimraf);
-    after(async () => {
-        try {
-            await rm(testDirPrefix + "*");
-        } catch (e) {
-            // ignore error
+        it("should handle the diabolical", () => {
+            const c = "../.././...////....foo//.bar.baz/./..//...///...qux./quux...quuz/./../corge//...///./.";
+            const s = sanitizeClassifier(c);
+            const e = "_.._._...____....foo__.bar.baz_._..__...___...qux._quux...quuz_._.._corge__...___._.";
+            assert(s === e);
+        });
+
+    });
+
+    describe("resolveClassifier", () => {
+
+        const gi: any = {
+            configuration: {
+                sdm: {
+                    docker: {
+                        registry: "kinks/bigsky",
+                    },
+                },
+            },
+            context: {
+                workspaceId: "TH3K1NK5",
+            },
+            goalEvent: {
+                branch: "preservation/society",
+                repo: {
+                    name: "village-green",
+                    owner: "TheKinks",
+                    providerId: "PyeReprise",
+                },
+                sha: "9932791f7adfd854b576125b058e9eb45b3da8b9",
+            },
+        };
+
+        it("should do nothing successfully", async () => {
+            for (const c of [undefined, "", "simple", "foo.bar", "foo..bar"]) {
+                const r = await resolveClassifier(c, gi);
+                assert(r === c);
+            }
+        });
+
+        it("should replace placeholders", async () => {
+            // tslint:disable-next-line:no-invalid-template-strings
+            const c = "star-struck_${repo.providerId}_${repo.owner}_${repo.name}_${sha}_PhenomenalCat";
+            const r = await resolveClassifier(c, gi);
+            const e = "star-struck_PyeReprise_TheKinks_village-green_9932791f7adfd854b576125b058e9eb45b3da8b9_PhenomenalCat";
+            assert(r === e);
+        });
+
+        it("should replace placeholders and provide defaults", async () => {
+            // tslint:disable-next-line:no-invalid-template-strings
+            const c = "star-struck_${repo.providerId}_${repo.owner}_${repo.name}_${brunch:hunch}_PhenomenalCat";
+            const r = await resolveClassifier(c, gi);
+            const e = "star-struck_PyeReprise_TheKinks_village-green_hunch_PhenomenalCat";
+            assert(r === e);
+        });
+
+        it("should replace nested placeholders", async () => {
+            // tslint:disable-next-line:no-invalid-template-strings
+            const c = "star-struck_${repo.providerId}_${repo.owner}_${repo.name}_${brunch:${sha}}_PhenomenalCat";
+            const r = await resolveClassifier(c, gi);
+            const e = "star-struck_PyeReprise_TheKinks_village-green_9932791f7adfd854b576125b058e9eb45b3da8b9_PhenomenalCat";
+            assert(r === e);
+        });
+
+        it("should replace and sanitize placeholders", async () => {
+            // tslint:disable-next-line:no-invalid-template-strings
+            const c = "star-struck_${sdm.docker.registry}_${repo.owner}_${repo.name}_${branch}_PhenomenalCat";
+            const r = await resolveClassifier(c, gi);
+            const e = "star-struck_kinks_bigsky_TheKinks_village-green_preservation_society_PhenomenalCat";
+            assert(r === e);
+        });
+
+    });
+
+    describe("CompressingGoalCache", () => {
+
+        const testDirPrefix = path.join(os.tmpdir(), "sdm-core-test-");
+
+        function testDir(): string {
+            return testDirPrefix + guid();
         }
+
+        async function createTempProject(fakePushId: RepoRef): Promise<LocalProject> {
+            const projectDir = testDir();
+            await fs.ensureDir(projectDir);
+            return NodeFsLocalProject.fromExistingDirectory(fakePushId, projectDir);
+        }
+
+        const ErrorProjectListenerRegistration: GoalProjectListenerRegistration = {
+            name: "Error",
+            listener: async () => { throw Error("Cache miss"); },
+            pushTest: AnyPush,
+        };
+
+        const rm = promisify(rimraf);
+        after(async () => {
+            try {
+                await rm(testDirPrefix + "*");
+            } catch (e) {
+                // ignore error
+            }
+        });
+
+        it("should cache and retrieve", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir(), store: testCache };
+
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } }],
+                onCacheMiss: ErrorProjectListenerRegistration,
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            // it should find it in the cache
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options)
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(await emptyProject.hasFile("test.txt"));
+        });
+
+        it("should cache and retrieve, excluding specific directories", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: ["**/*.txt", "!excludeme/**/*"] } }],
+                onCacheMiss: ErrorProjectListenerRegistration,
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await project.addFile("excludeme/test.txt", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            // it should find it in the cache
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options)
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(await emptyProject.hasFile("test.txt"));
+            assert(!await emptyProject.hasFile("excludeme/test.txt"));
+        });
+
+        it("should cache and retrieve complete directories", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { directory: "test" } }],
+                onCacheMiss: ErrorProjectListenerRegistration,
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test/test.txt", "test");
+            await project.addFile("test/test2.txt", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            // it should find it in the cache
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options)
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(await emptyProject.hasFile("test/test.txt"));
+            assert(await emptyProject.hasFile("test/test2.txt"));
+        });
+
+        it("should call fallback on cache miss", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const fallback: GoalProjectListenerRegistration = {
+                name: "fallback",
+                listener: async p => {
+                    await p.addFile("test2.txt", "test");
+                },
+            };
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } }],
+                onCacheMiss: [fallback],
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            // and clearing the cache
+            await cacheRemove(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            // it should not find it in the cache and call fallback
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options)
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(await emptyProject.hasFile("test2.txt"));
+        });
+
+        it("should create different archives", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } },
+                { classifier: "batches", pattern: { globPattern: "**/*.bat" } }],
+                onCacheMiss: ErrorProjectListenerRegistration,
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await project.addFile("test.bat", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options, "default", "batches")
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(await emptyProject.hasFile("test.txt"));
+            assert(await emptyProject.hasFile("test.bat"));
+        });
+
+        it("should create different archives and restore all", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } },
+                { classifier: "batches", pattern: { globPattern: "**/*.bat" } }],
+                onCacheMiss: ErrorProjectListenerRegistration,
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await project.addFile("test.bat", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options)
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(await emptyProject.hasFile("test.txt"));
+            assert(await emptyProject.hasFile("test.bat"));
+        });
+
+        it("should create different archives and be able to select one", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } },
+                { classifier: "batches", pattern: { globPattern: "**/*.bat" } }],
+                onCacheMiss: ErrorProjectListenerRegistration,
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await project.addFile("test.bat", "test");
+            await cachePut(options)
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options, "batches")
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(!await emptyProject.hasFile("test.txt"));
+            assert(await emptyProject.hasFile("test.bat"));
+        });
+
+        it("should create specific archives and fallback", async () => {
+            const fakePushId = fakePush().id;
+            fakePushId.sha = "testing";
+            const fakeGoal = fakeGoalInvocation(fakePushId);
+            const testCache = new CompressingGoalCache();
+            fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
+            fakeGoal.configuration.sdm.goalCache = testCache;
+            fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
+
+            const fallback: GoalProjectListenerRegistration = {
+                name: "fallback",
+                listener: async p => {
+                    await p.addFile("fallback.text", "test");
+                },
+            };
+            const options: GoalCacheOptions = {
+                entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } }, {
+                    classifier: "batches",
+                    pattern: { globPattern: "**/*.bat" },
+                }],
+                onCacheMiss: [fallback],
+            };
+            // when cache something
+            const project = await createTempProject(fakePushId);
+            await project.addFile("test.txt", "test");
+            await project.addFile("test.bat", "test");
+            await cachePut(options, "batches")
+                .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
+            const emptyProject = await createTempProject(fakePushId);
+            await cacheRestore(options, "default")
+                .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
+            assert(!await emptyProject.hasFile("test.txt"));
+            assert(!await emptyProject.hasFile("test.bat"));
+            assert(await emptyProject.hasFile("fallback.text"));
+        });
+
     });
 
-    it("should cache and retrieve", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir(), store: testCache };
-
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } }],
-            onCacheMiss: ErrorProjectListenerRegistration,
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        // it should find it in the cache
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options)
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(await emptyProject.hasFile("test.txt"));
-    });
-
-    it("should cache and retrieve, excluding specific directories", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: ["**/*.txt", "!excludeme/**/*"] } }],
-            onCacheMiss: ErrorProjectListenerRegistration,
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await project.addFile("excludeme/test.txt", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        // it should find it in the cache
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options)
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(await emptyProject.hasFile("test.txt"));
-        assert(!await emptyProject.hasFile("excludeme/test.txt"));
-    });
-
-    it("should cache and retrieve complete directories", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { directory: "test" } }],
-            onCacheMiss: ErrorProjectListenerRegistration,
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test/test.txt", "test");
-        await project.addFile("test/test2.txt", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        // it should find it in the cache
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options)
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(await emptyProject.hasFile("test/test.txt"));
-        assert(await emptyProject.hasFile("test/test2.txt"));
-    });
-
-    it("should call fallback on cache miss", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const fallback: GoalProjectListenerRegistration = {
-            name: "fallback",
-            listener: async p => {
-                await p.addFile("test2.txt", "test");
-            },
-        };
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } }],
-            onCacheMiss: [fallback],
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        // and clearing the cache
-        await cacheRemove(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        // it should not find it in the cache and call fallback
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options)
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(await emptyProject.hasFile("test2.txt"));
-    });
-
-    it("should call create different archives", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } },
-            { classifier: "batches", pattern: { globPattern: "**/*.bat" } }],
-            onCacheMiss: ErrorProjectListenerRegistration,
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await project.addFile("test.bat", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options, "default", "batches")
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(await emptyProject.hasFile("test.txt"));
-        assert(await emptyProject.hasFile("test.bat"));
-    });
-
-    it("should call create different archives and restore all", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } },
-            { classifier: "batches", pattern: { globPattern: "**/*.bat" } }],
-            onCacheMiss: ErrorProjectListenerRegistration,
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await project.addFile("test.bat", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options)
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(await emptyProject.hasFile("test.txt"));
-        assert(await emptyProject.hasFile("test.bat"));
-    });
-
-    it("should call create different archives and be able to select one", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } },
-            { classifier: "batches", pattern: { globPattern: "**/*.bat" } }],
-            onCacheMiss: ErrorProjectListenerRegistration,
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await project.addFile("test.bat", "test");
-        await cachePut(options)
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options, "batches")
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(!await emptyProject.hasFile("test.txt"));
-        assert(await emptyProject.hasFile("test.bat"));
-    });
-
-    it("should call create specific archives and fallback", async () => {
-        const fakePushId = fakePush().id;
-        fakePushId.sha = "testing";
-        const fakeGoal = fakeGoalInvocation(fakePushId);
-        const testCache = new CompressingGoalCache();
-        fakeGoal.progressLog = new LoggingProgressLog("test", "debug");
-        fakeGoal.configuration.sdm.goalCache = testCache;
-        fakeGoal.configuration.sdm.cache = { enabled: true, path: testDir() };
-
-        const fallback: GoalProjectListenerRegistration = {
-            name: "fallback",
-            listener: async p => {
-                await p.addFile("fallback.text", "test");
-            },
-        };
-        const options: GoalCacheOptions = {
-            entries: [{ classifier: "default", pattern: { globPattern: "**/*.txt" } }, {
-                classifier: "batches",
-                pattern: { globPattern: "**/*.bat" },
-            }],
-            onCacheMiss: [fallback],
-        };
-        // when cache something
-        const project = await createTempProject(fakePushId);
-        await project.addFile("test.txt", "test");
-        await project.addFile("test.bat", "test");
-        await cachePut(options, "batches")
-            .listener(project as any as GitProject, fakeGoal, GoalProjectListenerEvent.after);
-        const emptyProject = await createTempProject(fakePushId);
-        await cacheRestore(options, "default")
-            .listener(emptyProject as any as GitProject, fakeGoal, GoalProjectListenerEvent.before);
-        assert(!await emptyProject.hasFile("test.txt"));
-        assert(!await emptyProject.hasFile("test.bat"));
-        assert(await emptyProject.hasFile("fallback.text"));
-    });
 });

--- a/test/goal/cache/goalCaching.test.ts
+++ b/test/goal/cache/goalCaching.test.ts
@@ -38,7 +38,7 @@ import {
     cacheRestore,
     GoalCache,
     GoalCacheOptions,
-} from "../../../index";
+} from "../../../lib/goal/cache/goalCaching";
 
 class TestGoalArtifactCache implements GoalCache {
     private id: RepoRef;

--- a/test/machine/yaml/mapGoals.test.ts
+++ b/test/machine/yaml/mapGoals.test.ts
@@ -26,174 +26,137 @@ import { DockerContainerRegistration } from "../../../lib/goal/container/docker"
 import {
     GoalMaker,
     mapGoals,
-    resolvePlaceholder,
 } from "../../../lib/machine/yaml/mapGoals";
 
-describe("mapGoals", () => {
+describe("machine/yaml/mapGoals", () => {
 
-    it("should error for unknown goal", async () => {
-        const yaml = "unknown-goal";
-        try {
-            await mapGoals(undefined, yaml, {}, {}, {}, {});
-            assert.fail();
-        } catch (e) {
-            assert.deepStrictEqual(e.message, "Unable to construct goal from '\"unknown-goal\"'");
-        }
-    });
+    describe("mapGoals", () => {
 
-    it("should map immaterial goals", async () => {
-        const yaml = "immaterial";
-        const goals = await mapGoals(undefined, yaml, {}, {}, {}, {});
-        assert.deepStrictEqual(goals, ImmaterialGoals.andLock().goals);
-    });
+        it("should error for unknown goal", async () => {
+            const yaml = "unknown-goal";
+            try {
+                await mapGoals(undefined, yaml, {}, {}, {}, {});
+                assert.fail();
+            } catch (e) {
+                assert.deepStrictEqual(e.message, "Unable to construct goal from '\"unknown-goal\"'");
+            }
+        });
 
-    it("should map locking goal", async () => {
-        const yaml = "lock";
-        const goals = await mapGoals(undefined, yaml, {}, {}, {}, {});
-        assert.deepStrictEqual(goals, Locking);
-    });
+        it("should map immaterial goals", async () => {
+            const yaml = "immaterial";
+            const goals = await mapGoals(undefined, yaml, {}, {}, {}, {});
+            assert.deepStrictEqual(goals, ImmaterialGoals.andLock().goals);
+        });
 
-    it("should map additional goal", async () => {
-        const sampleGoal = goal({ displayName: "Sample Goal" });
-        const yaml = "sample_goal";
-        const goals = await mapGoals(undefined, yaml, { sampleGoal }, {}, {}, {});
-        assert.deepStrictEqual(goals, sampleGoal);
-    });
+        it("should map locking goal", async () => {
+            const yaml = "lock";
+            const goals = await mapGoals(undefined, yaml, {}, {}, {}, {});
+            assert.deepStrictEqual(goals, Locking);
+        });
 
-    it("should map goalMaker goal", async () => {
-        const sampleGoal = goal({ displayName: "Sample Goal" });
-        const sampleGoalMaker: GoalMaker = async () => sampleGoal;
-        const yaml = { sample_goal: { input: "version", output: { target: { pattern: { directory: "target" } }} } };
-        const goals = await mapGoals(undefined, yaml, {}, { sampleGoal: sampleGoalMaker }, {}, {});
-        assert.deepStrictEqual(goals, sampleGoal);
-    });
+        it("should map additional goal", async () => {
+            const sampleGoal = goal({ displayName: "Sample Goal" });
+            const yaml = "sample_goal";
+            const goals = await mapGoals(undefined, yaml, { sampleGoal }, {}, {}, {});
+            assert.deepStrictEqual(goals, sampleGoal);
+        });
 
-    it("should map goalMaker goal with parameters", async () => {
-        const yaml = {
-            sampleGoal: {
-                foo: "bar",
-            },
-        };
-        const sampleGoal = goal({ displayName: "Sample Goal" });
-        const sampleGoalMaker: GoalMaker = async (sdm, params) => {
-            assert.deepStrictEqual(params, yaml.sampleGoal);
-            return sampleGoal;
-        };
-        const goals = await mapGoals(undefined, yaml, {}, { sampleGoal: sampleGoalMaker }, {}, {});
-        assert.deepStrictEqual(goals, sampleGoal);
-    });
+        it("should map goalMaker goal", async () => {
+            const sampleGoal = goal({ displayName: "Sample Goal" });
+            const sampleGoalMaker: GoalMaker = async () => sampleGoal;
+            const yaml = { sample_goal: { input: "version", output: { target: { pattern: { directory: "target" } } } } };
+            const goals = await mapGoals(undefined, yaml, {}, { sampleGoal: sampleGoalMaker }, {}, {});
+            assert.deepStrictEqual(goals, sampleGoal);
+        });
 
-    it("should map container goal", async () => {
-        const yaml: DockerContainerRegistration = {
-            containers: [{
-                name: "mongo",
-                image: "mongo:latest",
-                volumeMounts: [{
+        it("should map goalMaker goal with parameters", async () => {
+            const yaml = {
+                sampleGoal: {
+                    foo: "bar",
+                },
+            };
+            const sampleGoal = goal({ displayName: "Sample Goal" });
+            const sampleGoalMaker: GoalMaker = async (sdm, params) => {
+                assert.deepStrictEqual(params, yaml.sampleGoal);
+                return sampleGoal;
+            };
+            const goals = await mapGoals(undefined, yaml, {}, { sampleGoal: sampleGoalMaker }, {}, {});
+            assert.deepStrictEqual(goals, sampleGoal);
+        });
+
+        it("should map container goal", async () => {
+            const yaml: DockerContainerRegistration = {
+                containers: [{
+                    name: "mongo",
+                    image: "mongo:latest",
+                    volumeMounts: [{
+                        name: "cache",
+                        mountPath: "/cache",
+                    }],
+                    secrets: [{
+                        env: [{ name: "TEST", value: { encrypted: "sdfsdg34049tzewrghiokblsvbjskdv" } }],
+                    }],
+                }],
+                volumes: [{
                     name: "cache",
-                    mountPath: "/cache",
+                    hostPath: {
+                        path: "/tmp/cache",
+                    },
                 }],
-                secrets: [{
-                    env: [{ name: "TEST", value: { encrypted: "sdfsdg34049tzewrghiokblsvbjskdv" } }],
+                input: ["dependencies"],
+                output: [{
+                    classifier: "scripts",
+                    pattern: {
+                        globPattern: "*/*.js",
+                    },
                 }],
-            }],
-            volumes: [{
-                name: "cache",
-                hostPath: {
-                    path: "/tmp/cache",
+                approval: true,
+                preApproval: true,
+                retry: true,
+                descriptions: {
+                    completed: "What am awesome mongo goal",
                 },
-            }],
-            input: ["dependencies"],
-            output: [{
-                classifier: "scripts",
-                pattern: {
-                    globPattern: "*/*.js",
-                },
-            }],
-            approval: true,
-            preApproval: true,
-            retry: true,
-            descriptions: {
-                completed: "What am awesome mongo goal",
-            },
-        } as any;
-        const goals = await mapGoals(undefined, yaml, {}, {}, {}, {}) as Container;
-        assert.deepStrictEqual(goals.definition.retryFeasible, true);
-        assert.deepStrictEqual(goals.definition.approvalRequired, true);
-        assert.deepStrictEqual(goals.definition.preApprovalRequired, true);
-        assert.deepStrictEqual(goals.definition.completedDescription, (yaml as any).descriptions.completed);
-        assert.deepStrictEqual(goals.registrations[0].volumes, yaml.volumes);
-        assert.deepStrictEqual(goals.registrations[0].input, yaml.input);
-        assert.deepStrictEqual(goals.registrations[0].output, yaml.output);
-    });
+            } as any;
+            const goals = await mapGoals(undefined, yaml, {}, {}, {}, {}) as Container;
+            assert.deepStrictEqual(goals.definition.retryFeasible, true);
+            assert.deepStrictEqual(goals.definition.approvalRequired, true);
+            assert.deepStrictEqual(goals.definition.preApprovalRequired, true);
+            assert.deepStrictEqual(goals.definition.completedDescription, (yaml as any).descriptions.completed);
+            assert.deepStrictEqual(goals.registrations[0].volumes, yaml.volumes);
+            assert.deepStrictEqual(goals.registrations[0].input, yaml.input);
+            assert.deepStrictEqual(goals.registrations[0].output, yaml.output);
+        });
 
-    it("should map goals from array", async () => {
-        const sampleGoal1 = goal({ displayName: "Sample Goal1" });
-        const sampleGoal2 = goal({ displayName: "Sample Goal2" });
-        const yaml = ["sampleGoal1", "sampleGoal2"];
-        const goals = await mapGoals(undefined, yaml, { sampleGoal1, sampleGoal2 }, {}, {}, {});
-        assert.deepStrictEqual(goals, [sampleGoal1, sampleGoal2]);
-    });
+        it("should map goals from array", async () => {
+            const sampleGoal1 = goal({ displayName: "Sample Goal1" });
+            const sampleGoal2 = goal({ displayName: "Sample Goal2" });
+            const yaml = ["sampleGoal1", "sampleGoal2"];
+            const goals = await mapGoals(undefined, yaml, { sampleGoal1, sampleGoal2 }, {}, {}, {});
+            assert.deepStrictEqual(goals, [sampleGoal1, sampleGoal2]);
+        });
 
-    it("should map referenced goal with parameters", async () => {
-        const yaml = [{ "atomist/npm-goal/publish@master": { parameters: { command: "build" } } }, "atomist/npm-goal/install@master"];
-        const goals = await mapGoals({ configuration: { http: { client: { factory: DefaultHttpClientFactory } } } } as any, yaml, {}, {}, {}, {});
-        assert(!!goals);
-    }).timeout(10000);
+        it("should map referenced goal with parameters", async () => {
+            const yaml = [{ "atomist/npm-goal/publish@master": { parameters: { command: "build" } } }, "atomist/npm-goal/install@master"];
+            const goals = await mapGoals({ configuration: { http: { client: { factory: DefaultHttpClientFactory } } } } as any, yaml, {}, {}, {}, {});
+            assert(!!goals);
+        }).timeout(10000);
 
-    it("should map referenced goal", async () => {
-        const yaml = "atomist/npm-goal/i-dont-exist@0.0.1";
-        try {
-            await mapGoals({ configuration: { http: { client: { factory: DefaultHttpClientFactory } } } } as any, yaml, {}, {}, {}, {});
-            assert.fail();
-        } catch (e) {
-            assert.deepStrictEqual(e.message, "Unable to construct goal from '\"atomist/npm-goal/i-dont-exist@0.0.1\"'");
-        }
-    }).timeout(10000);
+        it("should map referenced goal", async () => {
+            const yaml = "atomist/npm-goal/i-dont-exist@0.0.1";
+            try {
+                await mapGoals({ configuration: { http: { client: { factory: DefaultHttpClientFactory } } } } as any, yaml, {}, {}, {}, {});
+                assert.fail();
+            } catch (e) {
+                assert.deepStrictEqual(e.message, "Unable to construct goal from '\"atomist/npm-goal/i-dont-exist@0.0.1\"'");
+            }
+        }).timeout(10000);
 
-    it("should map item with parameters", async () => {
-        const yaml = [{ "@atomist/npm-goal/publish": { parameters: { command: "build" } } }];
-        const goals = await mapGoals({} as any, yaml, {}, {}, {}, {});
-        assert(!!goals);
-    }).timeout(10000);
+        it("should map item with parameters", async () => {
+            const yaml = [{ "@atomist/npm-goal/publish": { parameters: { command: "build" } } }];
+            const goals = await mapGoals({} as any, yaml, {}, {}, {}, {});
+            assert(!!goals);
+        }).timeout(10000);
 
-});
-
-describe("resolvePlaceholders", () => {
-
-    it("should replace text in value", async () => {
-        // tslint:disable-next-line:no-invalid-template-strings
-        const value = "The quick ${color} fox jumps over the ${attribute} dog";
-        const result = await resolvePlaceholder(value, {} as any, {
-            configuration: {
-                color: "brown",
-                attribute: "lazy",
-            },
-        } as any, {});
-        assert.deepStrictEqual(result, "The quick brown fox jumps over the lazy dog");
-    });
-
-    it("should replace entire object", async () => {
-        // tslint:disable-next-line:no-invalid-template-strings
-        const value = "${colors}";
-        const result = await resolvePlaceholder(value, {} as any, {
-            configuration: {
-                colors: {
-                    blue: "yes",
-                    orange: "nah",
-                },
-            },
-        } as any, {});
-        assert.deepStrictEqual(result, { blue: "yes", orange: "nah" });
-    });
-
-    it("should replace nested placeholders", async () => {
-        // tslint:disable
-        const value = "docker build . -f ${parameters.dockerfile:Dockerfile} -t ${parameters.registry:${push.repo.owner}}/${push.repo.name}:latest &&";
-        // tslint:enable
-        const result = await resolvePlaceholder(value, { push: { repo: { owner: "atomist", name: "sdm" } } } as any, {
-            configuration: {},
-        } as any, { dockerfile: "lib/Dockerfile" });
-        assert.deepStrictEqual(result, "docker build . -f lib/Dockerfile -t atomist/sdm:latest &&");
     });
 
 });

--- a/test/machine/yaml/resolvePlaceholder.test.ts
+++ b/test/machine/yaml/resolvePlaceholder.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import { resolvePlaceholder } from "../../../lib/machine/yaml/resolvePlaceholder";
+
+describe("machine/yaml/resolvePlaceholder", () => {
+
+    describe("resolvePlaceholder", () => {
+
+        it("should replace text in value", async () => {
+            // tslint:disable-next-line:no-invalid-template-strings
+            const value = "The quick ${color} fox jumps over the ${attribute} dog";
+            const result = await resolvePlaceholder(value, {} as any, {
+                configuration: {
+                    color: "brown",
+                    attribute: "lazy",
+                },
+            } as any, {});
+            assert.deepStrictEqual(result, "The quick brown fox jumps over the lazy dog");
+        });
+
+        it("should replace entire object", async () => {
+            // tslint:disable-next-line:no-invalid-template-strings
+            const value = "${colors}";
+            const result = await resolvePlaceholder(value, {} as any, {
+                configuration: {
+                    colors: {
+                        blue: "yes",
+                        orange: "nah",
+                    },
+                },
+            } as any, {});
+            assert.deepStrictEqual(result, { blue: "yes", orange: "nah" });
+        });
+
+        it("should replace nested placeholders", async () => {
+            // tslint:disable
+            const value = "docker build . -f ${parameters.dockerfile:Dockerfile} -t ${parameters.registry:${push.repo.owner}}/${push.repo.name}:latest &&";
+            // tslint:enable
+            const result = await resolvePlaceholder(value, { push: { repo: { owner: "atomist", name: "sdm" } } } as any, {
+                configuration: {},
+            } as any, { dockerfile: "lib/Dockerfile" });
+            assert.deepStrictEqual(result, "docker build . -f lib/Dockerfile -t atomist/sdm:latest &&");
+        });
+
+    });
+
+});


### PR DESCRIPTION
Add YAML-like placeholder replacement in strings to cache classifier
to allow user-defined scoping of cache items

Move resolvePlaceholder from machine/yaml/mapGoals.ts to its own file,
otherwise mocha exited successfully with no output.

Closes #213