### PR TITLE
Add goal to fulfill scheduled container goals

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,7 @@ export {
     DockerContainerRegistration,
 } from "./lib/goal/container/docker";
 export {
+    K8sContainerFulfiller,
     K8sContainerRegistration,
     K8sContainerSpecCallback,
     K8sGoalContainerSpec,

--- a/lib/goal/cache/goalCaching.ts
+++ b/lib/goal/cache/goalCaching.ts
@@ -32,6 +32,9 @@ import * as _ from "lodash";
 import { toArray } from "../../util/misc/array";
 import { CompressingGoalCache } from "./CompressingGoalCache";
 
+export const CacheInputGoalDataKey = "@atomist/sdm/input";
+export const CacheOutputGoalDataKey = "@atomist/sdm/output";
+
 /**
  * Goal cache interface for storing and retrieving arbitrary files produced
  * by the execution of a goal.
@@ -163,8 +166,8 @@ export function cachePut(options: GoalCacheOptions,
                 const { goalEvent } = gi;
                 const data = JSON.parse(goalEvent.data || "{}");
                 const newData = {
-                    "@atomist/sdm/output": [
-                        ...(data["@atomist/sdm/output"] || []),
+                    [CacheOutputGoalDataKey]: [
+                        ...(data[CacheOutputGoalDataKey] || []),
                         ...entries,
                     ],
                 };
@@ -271,8 +274,8 @@ export function cacheRestore(options: GoalCacheRestoreOptions,
             const { goalEvent } = gi;
             const data = JSON.parse(goalEvent.data || "{}");
             const newData = {
-                "@atomist/sdm/input": [
-                    ...(data["@atomist/sdm/input"] || []),
+                [CacheInputGoalDataKey]: [
+                    ...(data[CacheInputGoalDataKey] || []),
                     ...classifiersToBeRestored.map(c => ({
                         classifier: c,
                     })),

--- a/lib/goal/common/item.ts
+++ b/lib/goal/common/item.ts
@@ -22,7 +22,11 @@ import {
 } from "@atomist/sdm";
 import { resolvePlaceholder } from "../../machine/yaml/resolvePlaceholder";
 import { toArray } from "../../util/misc/array";
-import { CacheEntry } from "../cache/goalCaching";
+import {
+    CacheEntry,
+    CacheInputGoalDataKey,
+    CacheOutputGoalDataKey,
+} from "../cache/goalCaching";
 import { ContainerSecrets } from "../container/container";
 
 export function item(name: string,
@@ -56,8 +60,8 @@ export function item(name: string,
             return {
                 parameters: {
                     ...(parameters || {}),
-                    "@atomist/sdm/input": toArray(input),
-                    "@atomist/sdm/output": toArray(output),
+                    [CacheInputGoalDataKey]: toArray(input),
+                    [CacheOutputGoalDataKey]: toArray(output),
                     "@atomist/sdm/secrets": secrets,
                 },
             };

--- a/lib/goal/container/container.ts
+++ b/lib/goal/container/container.ts
@@ -52,6 +52,8 @@ import {
     runningInK8s,
 } from "./util";
 
+export const ContainerRegistrationGoalDataKey = "@atomist/sdm/container";
+
 /**
  * Create and return a container goal with the provided container
  * specification.

--- a/lib/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
+++ b/lib/handlers/events/delivery/goals/FulfillGoalOnRequested.ts
@@ -52,6 +52,8 @@ import { SdmGoalFulfillmentMethod } from "@atomist/sdm/lib/api/goal/SdmGoalMessa
 import * as os from "os";
 import {
     CacheEntry,
+    CacheInputGoalDataKey,
+    CacheOutputGoalDataKey,
     cachePut,
     cacheRestore,
 } from "../../../../goal/cache/goalCaching";
@@ -168,14 +170,14 @@ export class FulfillGoalOnRequested implements HandleEvent<OnAnyRequestedSdmGoal
 
             // Prepare cache project listeners for parameters
             if (!!goalInvocation.parameters) {
-                if (!!goalInvocation.parameters["@atomist/sdm/input"]) {
-                    const input: Array<{ classifier: string }> = goalInvocation.parameters["@atomist/sdm/input"];
+                if (!!goalInvocation.parameters[CacheInputGoalDataKey]) {
+                    const input: Array<{ classifier: string }> = goalInvocation.parameters[CacheInputGoalDataKey];
                     if (!!input && input.length > 0) {
                         listeners.push(cacheRestore({ entries: input }));
                     }
                 }
-                if (!!goalInvocation.parameters["@atomist/sdm/output"]) {
-                    const output: CacheEntry[] = goalInvocation.parameters["@atomist/sdm/output"];
+                if (!!goalInvocation.parameters[CacheOutputGoalDataKey]) {
+                    const output: CacheEntry[] = goalInvocation.parameters[CacheOutputGoalDataKey];
                     if (!!output && output.length > 0) {
                         listeners.push(cachePut({ entries: output }));
                     }

--- a/lib/pack/k8s/KubernetesFulfillmentGoalScheduler.ts
+++ b/lib/pack/k8s/KubernetesFulfillmentGoalScheduler.ts
@@ -27,12 +27,18 @@ import * as _ from "lodash";
 import {
     Container,
     ContainerRegistration,
+    ContainerRegistrationGoalDataKey,
 } from "../../goal/container/container";
 
 export interface KubernetesFulfillmentOptions {
     registration?: string | ((gi: GoalInvocation) => Promise<string>);
     name?: string | ((gi: GoalInvocation) => Promise<string>);
 }
+
+export const DefaultKubernetesFulfillmentOptions = {
+    registration: "@atomist/k8s-sdm",
+    name: "kubernetes-container-fulfill",
+};
 
 /**
  * GoalScheduler implementation that redirects goals to a registered k8s-sdm for
@@ -43,10 +49,7 @@ export interface KubernetesFulfillmentOptions {
  */
 export class KubernetesFulfillmentGoalScheduler implements GoalScheduler {
 
-    constructor(private readonly options: KubernetesFulfillmentOptions = {
-        registration: "@atomist/k8s-sdm",
-        name: "container-deploy",
-    }) {
+    constructor(private readonly options: KubernetesFulfillmentOptions = DefaultKubernetesFulfillmentOptions) {
     }
 
     public async schedule(gi: GoalInvocation): Promise<ExecuteGoalResult> {
@@ -82,7 +85,7 @@ export class KubernetesFulfillmentGoalScheduler implements GoalScheduler {
         const data: any = JSON.parse(goalEvent.data || "{}");
         const newData: any = {};
         delete registration.callback;
-        _.set<any>(newData, "@atomist/sdm/container", registration);
+        _.set<any>(newData, ContainerRegistrationGoalDataKey, registration);
 
         goalEvent.data = JSON.stringify(_.merge(data, newData));
 

--- a/test/pack/k8s/KubernetesFulfillmentGoalScheduler.test.ts
+++ b/test/pack/k8s/KubernetesFulfillmentGoalScheduler.test.ts
@@ -56,7 +56,7 @@ describe("KubernetesFulfillmentGoalScheduler", () => {
             assert.deepStrictEqual(g.state, SdmGoalState.requested);
             assert.deepStrictEqual(ge.fulfillment, {
                 registration: "@atomist/k8s-sdm",
-                name: "container-deploy",
+                name: "kubernetes-container-fulfill",
                 method: SdmGoalFulfillmentMethod.Sdm,
             });
             assert(!!ge.data);


### PR DESCRIPTION
Add standard container fulfiller goal with appropriate cache restoring
project listener.  The executor for this goal first schedules the
container as a Kubernetes job in scheduleK8sJob and then executes it
using the normal executeK8sJob function.

Centralize names of goal event data properties.